### PR TITLE
feat: add assign in cards with links for each person

### DIFF
--- a/web/src/ui/Visualizer/InfoBox.js
+++ b/web/src/ui/Visualizer/InfoBox.js
@@ -4,6 +4,7 @@ import { User } from 'react-feather'
 import Issue from '../components/icons/Issue'
 import Pr from '../components/icons/Pr'
 import './infoBox.scss'
+import {element} from "prop-types";
 
 const InfoBox = ({ data }) => {
   const openWebLink = () => {
@@ -24,7 +25,11 @@ const InfoBox = ({ data }) => {
     default:
       break
   }
-  const auhorLink = data.has_author
+  const authorLink = data.has_author
+  let assignLength = 0
+  if (data.has_assignee !== undefined) {
+    assignLength = data.has_assignee.length
+  }
   return (
     <Draggable>
       <div className="info-box">
@@ -43,10 +48,27 @@ const InfoBox = ({ data }) => {
           <div className="info-box-body">
             {data.title ? data.title.replace(/"/gi, '\'') : 'No title'}
           </div>
-          {auhorLink && (
+          {assignLength !== 0 && authorLink && (
+            <div>
+              <div className="info-box-assign-link">
+                <User size={16} />
+                Assign:&nbsp;
+                {data.has_assignee.map((element, i) => <a href={element} target="_blank" rel="noopener noreferrer">{element.toString().replace('https://github.com/', '')}
+                  {i !== assignLength-1? ', ' : ''}
+                </a>)}
+              </div>
+              <div className="info-box-assign-link">
+              <User size={16} />
+              Author:&nbsp;
+              <a href={`${authorLink}`} target="_blank" rel="noopener noreferrer">{authorLink.replace('https://github.com/', '')}</a>
+              </div>
+            </div>
+          )}
+          {authorLink && assignLength === 0 && (
           <div className="info-box-author-link">
             <User size={16} />
-            <a href={`${auhorLink}`} target="_blank" rel="noopener noreferrer">{auhorLink.replace('https://github.com/', '')}</a>
+             Author:&nbsp;
+            <a href={`${authorLink}`} target="_blank" rel="noopener noreferrer">{authorLink.replace('https://github.com/', '')}</a>
           </div>
           )}
           <div className="info-box-actions">

--- a/web/src/ui/Visualizer/infoBox.scss
+++ b/web/src/ui/Visualizer/infoBox.scss
@@ -4,8 +4,8 @@
   position: absolute;
   left: 0.5rem;
   top: 0.5rem;
-  width: 320px;
-  height: 160px;
+  width: 360px;
+  height: 180px;
   color: #383B62;
   background-color: #ffffff;
   border-radius: 6px;
@@ -54,11 +54,19 @@
     }
     .info-box-author-link {
       display: flex;
+      margin-top: 1.5rem;
       align-items: center;
       svg {
         margin-right: 0.35rem;
       }
     }
+    .info-box-assign-link {
+          display: flex;
+          align-items: center;
+          svg {
+            margin-right: 0.35rem;
+          }
+        }
   }
   .info-box-actions {
     position: absolute;


### PR DESCRIPTION
Resolve #548 

I first check if assignments exist, if so I loop through all the assignments to display them, and link their github to their nickname.

Before :

![before](https://user-images.githubusercontent.com/71339153/181290824-6fec8814-471f-44ef-84e5-2052af18eee6.png)

After :

![after](https://user-images.githubusercontent.com/71339153/181290895-c2f3da09-52e5-4ca6-8781-98f2987b70c0.png)

┆Issue is synchronized with this [Trello card](https://trello.com/c/FAriFh9g)
