### PR TITLE
feat: hydrate live GitHub refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ The editor includes syntax highlighting for DepViz Flow, JSON, and JSONL.
 Plain Flow and fenced Markdown blocks like ```` ```depviz ```` can both be
 pasted directly.
 
+Live can also hydrate GitHub refs directly from the browser. This is the
+backendless mode: it calls `api.github.com`, optionally with a token kept in
+`sessionStorage`, and updates titles, states, labels, owners, and URLs in the
+current graph. It is deliberately not a cache or sync backend.
+
 The static files live under `live/app/` and are deployable as-is through
 GitHub Pages. No Node.js build is required.
 

--- a/docs/POC.md
+++ b/docs/POC.md
@@ -13,6 +13,7 @@ It proves that DepViz can be useful locally before becoming a hosted product:
 - export one static HTML file
 - serve a stateless Live v1 app without a Node.js build
 - parse Markdown-friendly DepViz Flow input for humans
+- hydrate GitHub refs directly from the browser before adding a backend/cache
 
 ## Success Criteria
 
@@ -27,6 +28,7 @@ The POC succeeds if:
 - `depviz gen html` creates an inspectable static file
 - `depviz live` serves a browser app that accepts DepViz Flow, JSONL, or exported JSON
 - Live input has syntax highlighting for DepViz Flow, JSON, and JSONL
+- Live can refresh GitHub refs through `api.github.com` without a backend
 - every same-repo PR can publish a `/previews/pr-N/live/` Pages preview
 - fixture output is covered by golden tests
 

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.0.0';
+const assetVersion = 'v4.1.0-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 
 const dom = {
@@ -15,6 +15,8 @@ const dom = {
   graph: document.getElementById('graphView'),
   graphCanvas: document.getElementById('graphCanvas'),
   table: document.getElementById('tableView'),
+  githubToken: document.getElementById('githubTokenInput'),
+  hydrateGithub: document.getElementById('hydrateGithubBtn'),
   showExternal: document.getElementById('showExternal'),
   showLocal: document.getElementById('showLocal'),
   showClosed: document.getElementById('showClosed'),
@@ -49,6 +51,7 @@ function emptyExport() {
 }
 
 function boot() {
+  dom.githubToken.value = sessionStorage.getItem('depviz.githubToken') || '';
   wireEvents();
   const hashed = readHash();
   if (hashed) {
@@ -85,6 +88,8 @@ function wireEvents() {
   document.getElementById('shareBtn').addEventListener('click', shareLink);
   document.getElementById('exportBtn').addEventListener('click', exportJSON);
   document.getElementById('fileInput').addEventListener('change', readFile);
+  dom.githubToken.addEventListener('input', persistGitHubToken);
+  dom.hydrateGithub.addEventListener('click', hydrateGitHub);
 }
 
 async function loadSample() {
@@ -118,6 +123,115 @@ function update() {
     dom.status.textContent = 'input error';
   }
   render();
+}
+
+function persistGitHubToken() {
+  const token = dom.githubToken.value.trim();
+  if (token) sessionStorage.setItem('depviz.githubToken', token);
+  else sessionStorage.removeItem('depviz.githubToken');
+}
+
+async function hydrateGitHub() {
+  const refs = githubRefsForSnapshot(state.data.snapshot);
+  if (refs.length === 0) {
+    dom.status.textContent = 'no GitHub refs';
+    return;
+  }
+
+  dom.hydrateGithub.disabled = true;
+  dom.status.textContent = `hydrating ${refs.length} GitHub refs`;
+  dom.error.textContent = '';
+  try {
+    const token = dom.githubToken.value.trim();
+    const updates = [];
+    const failures = [];
+    for (const ref of refs) {
+      try {
+        updates.push(await fetchGitHubNode(ref, token));
+      } catch (err) {
+        failures.push(`${ref.id}: ${err.message}`);
+      }
+    }
+    if (updates.length > 0) {
+      state.data = mergeHydratedNodes(state.data, updates);
+      render();
+    }
+    dom.status.textContent = failures.length > 0
+      ? `hydrated ${updates.length}/${refs.length} GitHub refs`
+      : `hydrated ${updates.length} GitHub refs`;
+    dom.error.textContent = failures.slice(0, 2).join('  ');
+  } finally {
+    dom.hydrateGithub.disabled = false;
+  }
+}
+
+function githubRefsForSnapshot(snapshot) {
+  const seen = new Set();
+  return snapshot.nodes.flatMap((node) => {
+    const ref = parseGitHubNodeID(node.id);
+    if (!ref || seen.has(ref.id)) return [];
+    seen.add(ref.id);
+    return [ref];
+  });
+}
+
+function parseGitHubNodeID(id) {
+  const match = /^gh:([^#!]+)([#!])([0-9]+)$/.exec(id || '');
+  if (!match) return null;
+  return {
+    id,
+    repo: match[1],
+    marker: match[2],
+    number: match[3],
+  };
+}
+
+async function fetchGitHubNode(ref, token) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`https://api.github.com/repos/${ref.repo}/issues/${ref.number}`, { headers });
+  if (!res.ok) throw new Error(githubFetchError(res));
+  const issue = await res.json();
+  const isPR = Boolean(issue.pull_request);
+  const marker = ref.marker === '!' || isPR ? '!' : '#';
+  return normalizeNode({
+    id: ref.id,
+    kind: isPR ? 'pr' : 'issue',
+    title: issue.title || ref.id,
+    state: issue.state || 'unknown',
+    owner: issue.assignee?.login || issue.user?.login || '',
+    data_json: JSON.stringify({
+      hydrated: true,
+      labels: (issue.labels || []).map((label) => label.name || label),
+      number: issue.number,
+      repo: ref.repo,
+      source: 'github-browser',
+    }),
+    updated_at: issue.updated_at || '',
+    board_role: 'card',
+    url: issue.html_url || githubURL(ref.repo, marker, ref.number),
+    source_id: `github:${ref.repo}`,
+    external_id: `${marker}${ref.number}`,
+  });
+}
+
+function githubFetchError(res) {
+  if (res.status === 401 || res.status === 403) return `${res.status}; add a token or check access`;
+  if (res.status === 404) return '404; missing or private';
+  return `${res.status} ${res.statusText}`;
+}
+
+function mergeHydratedNodes(data, updates) {
+  const hydrated = new Map(updates.map((node) => [node.id, node]));
+  const snapshot = {
+    ...data.snapshot,
+    nodes: data.snapshot.nodes.map((node) => hydrated.get(node.id) || node),
+    edges: data.snapshot.edges,
+  };
+  return buildExportFromSnapshot(snapshot);
 }
 
 function updateHighlight(text) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -13,6 +13,8 @@
       <span id="status">stateless work graph</span>
     </div>
     <div class="actions">
+      <input id="githubTokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="GitHub token">
+      <button id="hydrateGithubBtn" type="button">Hydrate GitHub</button>
       <button id="sampleBtn" type="button">Load sample</button>
       <button id="shareBtn" type="button">Share link</button>
       <button id="exportBtn" type="button">Export JSON</button>
@@ -67,6 +69,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.0.0"></script>
+  <script src="./app.js?v=v4.1.0-dev"></script>
 </body>
 </html>

--- a/live/app/sample.depviz
+++ b/live/app/sample.depviz
@@ -1,17 +1,13 @@
 // Standalone Live demo: define nodes by hand so cards have titles and states.
-// With GitHub sync/export, keep only the repo line and relations below.
+// Click Hydrate GitHub to refresh public refs directly from api.github.com.
 board "DepViz v4 POC"
 
 repo moul/depviz
 
-#679 "Bootstrap depviz v4" [open] @v4
-#80 "Choose Flow syntax" [open] @live
-#81 "Hydrate refs from GitHub" [open] @github
-#85 "Merge the v4 bootstrap" [open] @release
-#156 "Cross-repo board example" [open] @multirepo
-moul/depviz2#5252 "External dependency" [open]
+#681 "SQLite dependency bump" [open] @deps
+#680 "Checkout workflow bump" [open] @deps
+#649 "DepViz V2 follow-up" [open] @planning
 note live-format "Decide Live input format"
 
-#679 depends on #80, #81 and blocks #85
-#156 depends on moul/depviz2#5252
-#679 addresses live-format
+#681 depends on #680 and addresses live-format
+#680 blocks #649

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -50,6 +50,11 @@ button.active {
   font-weight: 650;
 }
 
+button:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
 .topbar {
   min-height: 56px;
   padding: 10px 14px;
@@ -85,6 +90,21 @@ button.active {
   align-items: center;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.actions input {
+  width: 178px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--ink);
+  padding: 7px 9px;
+}
+
+.actions input:focus {
+  border-color: var(--teal);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.12);
+  outline: none;
 }
 
 .shell {
@@ -483,6 +503,7 @@ tr:last-child td {
   }
 
   .actions button,
+  .actions input,
   .viewTabs button {
     flex: 1 1 auto;
   }


### PR DESCRIPTION
## What

Adds a backendless GitHub hydration pass to DepViz Live.

- Adds an optional GitHub token field stored only in sessionStorage
- Adds a Hydrate GitHub button that fetches current refs from api.github.com
- Updates node title, kind, state, owner, labels, URL, and updated_at in the current in-browser graph
- Keeps Flow/share links token-free and keeps hydration as a local one-shot, not a sync backend
- Refreshes the sample to public refs so the unauthenticated demo works

## Why

This shows what the no-backend version feels like before adding an auth broker, durable cache, server-side sync, or GitHub App permissions.

## Preview

https://moul.github.io/depviz/previews/pr-682/live/

## Verification

- go test ./...
- go vet ./...
- node --check live/app/app.js
- Local browser smoke: sample loads, Hydrate GitHub fetches public refs, #680 title becomes "chore(deps): bump actions/checkout from 4 to 6", brief/stale stats recalculate.
- Public preview smoke: https://moul.github.io/depviz/previews/pr-682/live/ hydrates 3 GitHub refs without a backend.