### PR TITLE
feat: add click GitHub auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,13 @@ The editor includes syntax highlighting for DepViz Flow, JSON, and JSONL.
 Plain Flow and fenced Markdown blocks like ```` ```depviz ```` can both be
 pasted directly.
 
-Live can also hydrate GitHub refs directly from the browser. This is the
-backendless mode: it calls `api.github.com`, optionally with a token kept in
-`sessionStorage`, and updates titles, states, labels, owners, and URLs in the
-current graph. It is deliberately not a cache or sync backend.
+Live can also refresh GitHub refs directly from the browser. This is the
+backendless mode: it calls `api.github.com`, optionally with a token kept only
+in `sessionStorage`, and updates titles, states, labels, owners, and URLs in
+the current graph. `Connect GitHub` opens GitHub's fine-grained token form with
+the read-only repo permissions DepViz needs prefilled; `Use copied token` then
+loads the generated token from the clipboard. It is deliberately not a cache,
+sync backend, or full OAuth flow yet.
 
 The static files live under `live/app/` and are deployable as-is through
 GitHub Pages. No Node.js build is required.

--- a/README.md
+++ b/README.md
@@ -138,12 +138,15 @@ pasted directly.
 Live can also refresh GitHub refs directly from the browser. This is the
 backendless mode: it calls `api.github.com`, optionally with a token kept only
 in `sessionStorage`, and updates titles, states, labels, owners, and URLs in
-the current graph. `Connect GitHub` opens GitHub's fine-grained token form with
-the read-only repo permissions DepViz needs prefilled; `Use copied token` then
-loads the generated token from the clipboard. It is deliberately not a cache,
-sync backend, or full OAuth flow yet. Refreshed refs are shown in the Brief
-summary even when closed cards are hidden, and public refs fall back to
-unauthenticated GitHub reads if the current token lacks scope.
+the current graph. PRs also pull review and CI/check signals when GitHub exposes
+them, so Live can show compact badges for type, lifecycle, review, and CI state.
+`Connect GitHub` opens GitHub's fine-grained token form with the read-only repo
+permissions DepViz needs prefilled: metadata, issues, pull requests, checks, and
+commit statuses. `Use copied token` then loads the generated token from the
+clipboard. It is deliberately not a cache, sync backend, or full OAuth flow yet.
+Refreshed refs are shown in the Brief summary even when closed cards are hidden,
+and public refs fall back to unauthenticated GitHub reads if the current token
+lacks scope.
 
 The static files live under `live/app/` and are deployable as-is through
 GitHub Pages. No Node.js build is required.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ in `sessionStorage`, and updates titles, states, labels, owners, and URLs in
 the current graph. `Connect GitHub` opens GitHub's fine-grained token form with
 the read-only repo permissions DepViz needs prefilled; `Use copied token` then
 loads the generated token from the clipboard. It is deliberately not a cache,
-sync backend, or full OAuth flow yet.
+sync backend, or full OAuth flow yet. Refreshed refs are shown in the Brief
+summary even when closed cards are hidden, and public refs fall back to
+unauthenticated GitHub reads if the current token lacks scope.
 
 The static files live under `live/app/` and are deployable as-is through
 GitHub Pages. No Node.js build is required.

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.2-dev';
+const assetVersion = 'v4.1.4-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -34,6 +34,7 @@ const state = {
   showExternal: true,
   showLocal: true,
   showClosed: false,
+  githubRefresh: [],
   data: emptyExport(),
 };
 
@@ -124,6 +125,7 @@ function readFile(event) {
 
 function update() {
   const text = dom.input.value;
+  state.githubRefresh = [];
   updateHighlight(text);
   dom.lineCount.textContent = `${countLines(text)} lines`;
   try {
@@ -250,11 +252,17 @@ async function hydrateGitHub() {
     }
     if (updates.length > 0) {
       state.data = mergeHydratedNodes(state.data, updates);
+      state.githubRefresh = githubRefreshItems(updates);
       render();
     }
-    dom.status.textContent = failures.length > 0
+    const statusParts = [failures.length > 0
       ? `refreshed ${updates.length}/${refs.length} GitHub refs`
-      : `refreshed ${updates.length} GitHub refs`;
+      : `refreshed ${updates.length} GitHub refs`];
+    const closedHidden = !state.showClosed ? updates.filter(isClosed).length : 0;
+    const publicFallbacks = updates.filter((node) => nodeData(node).auth_fallback).length;
+    if (closedHidden > 0) statusParts.push(`${closedHidden} closed in refresh summary`);
+    if (publicFallbacks > 0) statusParts.push(`${publicFallbacks} via public fallback`);
+    dom.status.textContent = statusParts.join('; ');
     dom.error.textContent = failures.slice(0, 2).join('  ');
   } finally {
     dom.hydrateGithub.disabled = false;
@@ -283,12 +291,15 @@ function parseGitHubNodeID(id) {
 }
 
 async function fetchGitHubNode(ref, token) {
-  const headers = {
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-  if (token) headers.Authorization = `Bearer ${token}`;
-  const res = await fetch(`https://api.github.com/repos/${ref.repo}/issues/${ref.number}`, { headers });
+  let authFallback = false;
+  let res = await fetchGitHubIssue(ref, token);
+  if (!res.ok && token && [401, 403, 404].includes(res.status)) {
+    const publicRes = await fetchGitHubIssue(ref, '');
+    if (publicRes.ok) {
+      res = publicRes;
+      authFallback = true;
+    }
+  }
   if (!res.ok) throw new Error(githubFetchError(res, token));
   const issue = await res.json();
   const isPR = Boolean(issue.pull_request);
@@ -301,6 +312,7 @@ async function fetchGitHubNode(ref, token) {
     owner: issue.assignee?.login || issue.user?.login || '',
     data_json: JSON.stringify({
       hydrated: true,
+      auth_fallback: authFallback,
       labels: (issue.labels || []).map((label) => label.name || label),
       number: issue.number,
       repo: ref.repo,
@@ -312,6 +324,15 @@ async function fetchGitHubNode(ref, token) {
     source_id: `github:${ref.repo}`,
     external_id: `${marker}${ref.number}`,
   });
+}
+
+async function fetchGitHubIssue(ref, token) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return fetch(`https://api.github.com/repos/${ref.repo}/issues/${ref.number}`, { headers });
 }
 
 function githubFetchError(res, token) {
@@ -333,6 +354,17 @@ function mergeHydratedNodes(data, updates) {
     edges: data.snapshot.edges,
   };
   return buildExportFromSnapshot(snapshot);
+}
+
+function githubRefreshItems(nodes) {
+  return nodes.map((node) => ({
+    id: node.id,
+    title: node.title,
+    kind: node.kind,
+    state: node.state,
+    url: node.url,
+    reason: `${node.kind} ${node.state}${isClosed(node) && !state.showClosed ? '; closed hidden by filter' : ''}`,
+  })).slice(0, 12);
 }
 
 function updateHighlight(text) {
@@ -993,7 +1025,11 @@ function renderStats(counts) {
 }
 
 function renderBrief(brief) {
+  const githubRefresh = state.githubRefresh.length
+    ? briefSection('GitHub refresh', state.githubRefresh, false)
+    : '';
   dom.brief.innerHTML = `<div class="briefGrid">
+    ${githubRefresh}
     ${briefSection('Next move', brief.next_move ? [brief.next_move] : [], true)}
     ${briefSection('Ready now', brief.ready || [], false)}
     ${briefSection('Blocking most work', brief.blockers || [], false)}
@@ -1108,7 +1144,7 @@ function encodeBase64URL(text) {
 }
 
 function decodeBase64URL(text) {
-  const padded = text.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((text.length + 3) % 4);
+  const padded = text.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (text.length % 4)) % 4);
   const binary = atob(padded);
   return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)));
 }
@@ -1119,10 +1155,14 @@ function countLines(text) {
 }
 
 function labels(node) {
+  return nodeData(node).labels || [];
+}
+
+function nodeData(node) {
   try {
-    return JSON.parse(node.data_json || '{}').labels || [];
+    return JSON.parse(node.data_json || '{}');
   } catch {
-    return [];
+    return {};
   }
 }
 

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -210,6 +210,8 @@ function buildGitHubTokenURL(refs) {
     metadata: 'read',
     issues: 'read',
     pull_requests: 'read',
+    checks: 'read',
+    statuses: 'read',
   });
   if (owners.length === 1) params.set('target_name', owners[0]);
   return `${githubFineGrainedTokenURL}?${params.toString()}`;
@@ -289,32 +291,66 @@ function parseGitHubNodeID(id) {
 }
 
 async function fetchGitHubNode(ref, token) {
-  let authFallback = false;
-  let res = await fetchGitHubIssue(ref, token);
-  if (!res.ok && token && [401, 403, 404].includes(res.status)) {
-    const publicRes = await fetchGitHubIssue(ref, '');
-    if (publicRes.ok) {
-      res = publicRes;
-      authFallback = true;
-    }
-  }
-  if (!res.ok) throw new Error(githubFetchError(res, token));
-  const issue = await res.json();
+  const issueResult = await fetchGitHubJSON(ref, token, `/repos/${ref.repo}/issues/${ref.number}`);
+  if (!issueResult.ok) throw new Error(githubFetchError(issueResult.res, token));
+  const issue = issueResult.data;
   const isPR = Boolean(issue.pull_request);
   const marker = ref.marker === '!' || isPR ? '!' : '#';
+  let authFallback = issueResult.authFallback;
+  let pr = null;
+  let reviews = [];
+  let checkRuns = null;
+  let status = null;
+  const metadataErrors = [];
+
+  if (isPR) {
+    const prResult = await fetchOptionalGitHubJSON(ref, token, `/repos/${ref.repo}/pulls/${ref.number}`);
+    authFallback = authFallback || prResult.authFallback;
+    pr = prResult.data;
+    if (prResult.error) metadataErrors.push(`pr:${prResult.error}`);
+
+    const reviewsResult = await fetchOptionalGitHubJSON(ref, token, `/repos/${ref.repo}/pulls/${ref.number}/reviews`);
+    authFallback = authFallback || reviewsResult.authFallback;
+    reviews = Array.isArray(reviewsResult.data) ? reviewsResult.data : [];
+    if (reviewsResult.error) metadataErrors.push(`review:${reviewsResult.error}`);
+
+    const headSHA = pr?.head?.sha || '';
+    if (headSHA) {
+      const checkRunsResult = await fetchOptionalGitHubJSON(ref, token, `/repos/${ref.repo}/commits/${headSHA}/check-runs?per_page=100`);
+      authFallback = authFallback || checkRunsResult.authFallback;
+      checkRuns = checkRunsResult.data;
+      if (checkRunsResult.error) metadataErrors.push(`checks:${checkRunsResult.error}`);
+
+      const statusResult = await fetchOptionalGitHubJSON(ref, token, `/repos/${ref.repo}/commits/${headSHA}/status`);
+      authFallback = authFallback || statusResult.authFallback;
+      status = statusResult.data;
+      if (statusResult.error) metadataErrors.push(`status:${statusResult.error}`);
+    }
+  }
+
+  const lifecycle = githubLifecycle(issue, pr);
+  const review = summarizeGitHubReviews(reviews, pr);
+  const ci = summarizeGitHubCI(checkRuns, status);
   return normalizeNode({
     id: ref.id,
     kind: isPR ? 'pr' : 'issue',
     title: issue.title || ref.id,
-    state: issue.state || 'unknown',
+    state: lifecycle.state,
     owner: issue.assignee?.login || issue.user?.login || '',
     data_json: JSON.stringify({
       hydrated: true,
       auth_fallback: authFallback,
+      lifecycle,
+      review,
+      ci,
+      metadata_errors: metadataErrors,
       labels: (issue.labels || []).map((label) => label.name || label),
       number: issue.number,
       repo: ref.repo,
       source: 'github-browser',
+      head_sha: pr?.head?.sha || '',
+      base_ref: pr?.base?.ref || '',
+      head_ref: pr?.head?.ref || '',
     }),
     updated_at: issue.updated_at || '',
     board_role: 'card',
@@ -324,13 +360,33 @@ async function fetchGitHubNode(ref, token) {
   });
 }
 
-async function fetchGitHubIssue(ref, token) {
+async function fetchOptionalGitHubJSON(ref, token, path) {
+  const result = await fetchGitHubJSON(ref, token, path);
+  if (result.ok) return result;
+  return { ...result, data: null, error: githubFetchError(result.res, token) };
+}
+
+async function fetchGitHubJSON(ref, token, path) {
+  let authFallback = false;
+  let res = await githubFetch(path, token);
+  if (!res.ok && token && [401, 403, 404].includes(res.status)) {
+    const publicRes = await githubFetch(path, '');
+    if (publicRes.ok) {
+      res = publicRes;
+      authFallback = true;
+    }
+  }
+  if (!res.ok) return { ok: false, res, data: null, authFallback };
+  return { ok: true, res, data: await res.json(), authFallback };
+}
+
+async function githubFetch(path, token) {
   const headers = {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
   };
   if (token) headers.Authorization = `Bearer ${token}`;
-  return fetch(`https://api.github.com/repos/${ref.repo}/issues/${ref.number}`, { headers });
+  return fetch(`https://api.github.com${path}`, { headers });
 }
 
 function githubFetchError(res, token) {
@@ -352,6 +408,82 @@ function mergeHydratedNodes(data, updates) {
     edges: data.snapshot.edges,
   };
   return buildExportFromSnapshot(snapshot);
+}
+
+function githubLifecycle(issue, pr) {
+  if (pr?.merged_at || pr?.merged) {
+    return { state: 'merged', phase: 'done', merged: true, draft: false };
+  }
+  if (pr?.draft) {
+    return { state: 'draft', phase: 'review', merged: false, draft: true };
+  }
+  const state = issue.state || pr?.state || 'unknown';
+  const phase = state === 'open' ? 'active' : 'done';
+  return { state, phase, merged: false, draft: false };
+}
+
+function summarizeGitHubReviews(reviews, pr) {
+  const requested = [
+    ...(pr?.requested_reviewers || []).map((reviewer) => reviewer.login).filter(Boolean),
+    ...(pr?.requested_teams || []).map((team) => team.slug || team.name).filter(Boolean),
+  ];
+  const latestByUser = new Map();
+  for (const review of reviews || []) {
+    const user = review.user?.login || '';
+    const stateName = String(review.state || '').toUpperCase();
+    if (!user || !stateName || stateName === 'PENDING') continue;
+    latestByUser.set(user, stateName);
+  }
+  const latest = Array.from(latestByUser.values());
+  const approvals = latest.filter((stateName) => stateName === 'APPROVED').length;
+  const changesRequested = latest.filter((stateName) => stateName === 'CHANGES_REQUESTED').length;
+  const comments = latest.filter((stateName) => stateName === 'COMMENTED').length;
+  let stateName = 'none';
+  if (changesRequested > 0) stateName = 'changes_requested';
+  else if (approvals > 0) stateName = 'approved';
+  else if (requested.length > 0) stateName = 'requested';
+  else if (comments > 0) stateName = 'commented';
+  return {
+    state: stateName,
+    approvals,
+    changes_requested: changesRequested,
+    comments,
+    requested,
+    total: reviews?.length || 0,
+  };
+}
+
+function summarizeGitHubCI(checkRunsPayload, statusPayload) {
+  const runs = checkRunsPayload?.check_runs || [];
+  const statusState = String(statusPayload?.state || '').toLowerCase();
+  const failedConclusions = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure']);
+  const okConclusions = new Set(['success', 'neutral', 'skipped']);
+  let failed = 0;
+  let pending = 0;
+  let passed = 0;
+  for (const run of runs) {
+    const status = String(run.status || '').toLowerCase();
+    const conclusion = String(run.conclusion || '').toLowerCase();
+    if (failedConclusions.has(conclusion)) failed++;
+    else if (status !== 'completed' || !conclusion) pending++;
+    else if (okConclusions.has(conclusion)) passed++;
+  }
+  if (['failure', 'error'].includes(statusState)) failed++;
+  if (statusState === 'pending') pending++;
+
+  let stateName = 'none';
+  if (failed > 0) stateName = 'failure';
+  else if (pending > 0) stateName = 'pending';
+  else if (runs.length > 0 || statusState === 'success') stateName = 'success';
+
+  return {
+    state: stateName,
+    total: runs.length,
+    passed,
+    failed,
+    pending,
+    status_state: statusState || 'none',
+  };
 }
 
 function githubRefreshItems(nodes) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,7 +1,8 @@
-const assetVersion = 'v4.1.4-dev';
+const assetVersion = 'v4.1.5-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
+const views = new Set(['brief', 'graph', 'table']);
 
 const dom = {
   input: document.getElementById('sourceInput'),
@@ -61,6 +62,7 @@ function boot() {
   dom.githubToken.value = sessionStorage.getItem(githubTokenStorageKey) || '';
   refreshGitHubAuthUI();
   wireEvents();
+  setView(readURLView(), { persist: false, renderNow: false });
   const hashed = readHash();
   if (hashed) {
     dom.input.value = hashed;
@@ -85,11 +87,7 @@ function wireEvents() {
   }
   for (const btn of document.querySelectorAll('[data-view]')) {
     btn.addEventListener('click', () => {
-      state.view = btn.dataset.view;
-      document.querySelectorAll('[data-view]').forEach((item) => {
-        item.classList.toggle('active', item === btn);
-      });
-      render();
+      setView(btn.dataset.view, { persist: true, renderNow: true });
     });
   }
   document.getElementById('sampleBtn').addEventListener('click', loadSample);
@@ -1109,9 +1107,33 @@ function visibleNodes(nodes) {
   });
 }
 
+function setView(view, options = {}) {
+  const next = views.has(view) ? view : 'brief';
+  state.view = next;
+  document.querySelectorAll('[data-view]').forEach((item) => {
+    item.classList.toggle('active', item.dataset.view === next);
+  });
+  if (options.persist !== false) writeURLView(next);
+  if (options.renderNow !== false) render();
+}
+
+function readURLView() {
+  const view = new URLSearchParams(location.search).get('view') || 'brief';
+  return views.has(view) ? view : 'brief';
+}
+
+function writeURLView(view) {
+  const url = new URL(location.href);
+  if (view === 'brief') url.searchParams.delete('view');
+  else url.searchParams.set('view', view);
+  history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
 function shareLink() {
   const encoded = encodeBase64URL(dom.input.value);
-  history.replaceState(null, '', `#data=${encoded}`);
+  const url = new URL(location.href);
+  url.hash = `data=${encoded}`;
+  history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
   navigator.clipboard?.writeText(location.href);
   dom.status.textContent = 'share link copied';
 }

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.5-dev';
+const assetVersion = 'v4.1.7-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -455,7 +455,7 @@ function summarizeGitHubReviews(reviews, pr) {
 
 function summarizeGitHubCI(checkRunsPayload, statusPayload) {
   const runs = checkRunsPayload?.check_runs || [];
-  const statusState = String(statusPayload?.state || '').toLowerCase();
+  const statusState = Number(statusPayload?.total_count || 0) > 0 ? String(statusPayload?.state || '').toLowerCase() : '';
   const failedConclusions = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure']);
   const okConclusions = new Set(['success', 'neutral', 'skipped']);
   let failed = 0;
@@ -487,12 +487,7 @@ function summarizeGitHubCI(checkRunsPayload, statusPayload) {
 }
 
 function githubRefreshItems(nodes) {
-  return nodes.map((node) => ({
-    id: node.id,
-    title: node.title,
-    kind: node.kind,
-    state: node.state,
-    url: node.url,
+  return nodes.map((node) => briefItem(node, {
     reason: `${node.kind} ${node.state}${isClosed(node) && !state.showClosed ? '; closed hidden by filter' : ''}`,
   })).slice(0, 12);
 }
@@ -1065,28 +1060,23 @@ function buildBrief(snapshot) {
     if (isClosed(node)) continue;
     const active = activeBlockers(node.id, nodes, blockersByNode);
     if (active.length === 0 && !isPlaceholder(node)) {
-      ready.push({
-        id: node.id,
-        title: node.title,
-        kind: node.kind,
-        state: node.state,
-        url: node.url,
+      ready.push(briefItem(node, {
         reason: readyReason(node, blockedByNode.get(node.id)),
         impact: activeBlockedCount(node.id, nodes, blockedByNode),
-      });
+      }));
     } else {
       blocked++;
     }
     if (isLocal(node)) {
-      localOnly.push({ id: node.id, title: node.title, kind: node.kind, state: node.state, reason: 'local-only planning card' });
+      localOnly.push(briefItem(node, { reason: 'local-only planning card' }));
     }
     if (isPlaceholder(node) && !isLocal(node)) {
-      stale.push({ id: node.id, title: node.title, kind: node.kind, state: node.state, url: node.url, reason: 'placeholder external ref; sync a wider scope' });
+      stale.push(briefItem(node, { reason: 'placeholder external ref; sync a wider scope' }));
       continue;
     }
     const updated = Date.parse(node.updated_at || '');
     if (!isLocal(node) && Number.isFinite(updated) && updated < cutoff) {
-      stale.push({ id: node.id, title: node.title, kind: node.kind, state: node.state, url: node.url, reason: 'not updated in 30+ days' });
+      stale.push(briefItem(node, { reason: 'not updated in 30+ days' }));
     }
   }
 
@@ -1095,15 +1085,10 @@ function buildBrief(snapshot) {
     if (!node || isClosed(node)) continue;
     const impact = activeBlockedCount(blockerID, nodes, blockedByNode);
     if (impact === 0) continue;
-    blockers.push({
-      id: node.id,
-      title: node.title,
-      kind: node.kind,
-      state: node.state,
-      url: node.url,
+    blockers.push(briefItem(node, {
       impact,
       reason: `blocks ${impact} active card${impact === 1 ? '' : 's'}`,
-    });
+    }));
   }
 
   sortItems(ready);
@@ -1126,6 +1111,18 @@ function buildBrief(snapshot) {
       local_only: localOnly.length,
       stale: stale.length,
     },
+  };
+}
+
+function briefItem(node, extra = {}) {
+  return {
+    id: node.id,
+    title: node.title,
+    kind: node.kind,
+    state: node.state,
+    url: node.url,
+    badges: nodeBadges(node),
+    ...extra,
   };
 }
 
@@ -1179,7 +1176,8 @@ function renderItem(item) {
   const url = item.url || item.URL || '';
   const reason = esc(item.reason || item.Reason || '');
   const label = url ? `<a href="${esc(url)}">${id}</a>` : id;
-  return `<div class="item"><strong>${label} ${title}</strong><div class="reason">${reason}</div></div>`;
+  const badges = badgesHTML(item.badges || plainBadges(item));
+  return `<div class="item"><div class="itemHead"><strong>${label} ${title}</strong>${badges}</div><div class="reason">${reason}</div></div>`;
 }
 
 function renderGraph(snapshot, nodes) {
@@ -1209,12 +1207,12 @@ function renderGraph(snapshot, nodes) {
   html += '</svg>';
   for (const node of nodes) {
     const pos = positions.get(node.id);
-    const klass = ['nodeCard', isLocal(node) ? 'note' : '', isClosed(node) ? 'closed' : '', isBlocked(node.id, snapshot) ? 'blocked' : 'ready'].filter(Boolean).join(' ');
+    const klass = ['nodeCard', ...nodeCardClasses(node), isBlocked(node.id, snapshot) ? 'blocked' : 'ready'].filter(Boolean).join(' ');
     const id = node.url ? `<a href="${esc(node.url)}">${esc(node.id)}</a>` : esc(node.id);
     html += `<article class="${klass}" style="transform:translate(${pos.x}px, ${pos.y}px)">
       <div class="nodeId">${id}</div>
       <div class="nodeTitle">${esc(node.title)}</div>
-      <div class="nodeState">${esc(node.kind)} - ${esc(node.state)}</div>
+      ${badgesHTML(nodeBadges(node))}
     </article>`;
   }
   html += '</div>';
@@ -1224,9 +1222,9 @@ function renderGraph(snapshot, nodes) {
 function renderTable(nodes) {
   const rows = nodes.map((node) => {
     const id = node.url ? `<a href="${esc(node.url)}">${esc(node.id)}</a>` : esc(node.id);
-    return `<tr><td>${id}</td><td>${esc(node.title)}</td><td>${esc(node.kind)}</td><td>${esc(node.state)}</td><td>${esc(labels(node).join(', '))}</td></tr>`;
+    return `<tr class="${nodeCardClasses(node).join(' ')}"><td>${id}</td><td>${badgesHTML(nodeBadges(node))}</td><td>${esc(node.title)}</td><td>${esc(labels(node).join(', '))}</td></tr>`;
   }).join('');
-  dom.table.innerHTML = `<table><thead><tr><th>ID</th><th>Title</th><th>Kind</th><th>State</th><th>Labels</th></tr></thead><tbody>${rows}</tbody></table>`;
+  dom.table.innerHTML = `<table><thead><tr><th>ID</th><th>Signals</th><th>Title</th><th>Labels</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 
 function visibleNodes(nodes) {
@@ -1234,7 +1232,7 @@ function visibleNodes(nodes) {
     if (!state.showClosed && isClosed(node)) return false;
     if (!state.showLocal && isLocal(node)) return false;
     if (!state.showExternal && !isLocal(node)) return false;
-    const hay = [node.id, node.title, node.state, node.kind, labels(node).join(' ')].join(' ').toLowerCase();
+    const hay = [node.id, node.title, node.state, node.kind, badgeText(nodeBadges(node)), labels(node).join(' ')].join(' ').toLowerCase();
     return !state.filter || hay.includes(state.filter);
   });
 }
@@ -1306,6 +1304,96 @@ function decodeBase64URL(text) {
 function countLines(text) {
   if (!text) return 0;
   return text.split(/\r?\n/).length;
+}
+
+function nodeCardClasses(node) {
+  const data = nodeData(node);
+  const lifecycle = data.lifecycle?.state || node.state || 'unknown';
+  const ci = data.ci?.state || 'none';
+  const review = data.review?.state || 'none';
+  return [
+    isLocal(node) ? 'note' : '',
+    isClosed(node) ? 'closed' : '',
+    `kind-${badgeClass(node.kind || 'task')}`,
+    `life-${badgeClass(lifecycle)}`,
+    node.kind === 'pr' ? `ci-${badgeClass(ci)}` : '',
+    node.kind === 'pr' ? `review-${badgeClass(review)}` : '',
+  ];
+}
+
+function nodeBadges(node) {
+  const data = nodeData(node);
+  const badges = [];
+  if (isLocal(node)) {
+    badges.push(badge('type-local', '📝 note'));
+    return badges;
+  }
+  badges.push(typeBadge(node));
+  badges.push(lifecycleBadge(data.lifecycle?.state || node.state));
+  if (node.kind === 'pr') {
+    badges.push(reviewBadge(data.review || {}));
+    badges.push(ciBadge(data.ci || {}));
+  }
+  if (data.auth_fallback) badges.push(badge('auth-public', '🌐 public'));
+  return badges.filter(Boolean);
+}
+
+function plainBadges(item) {
+  const kind = item.kind || item.Kind || 'task';
+  const state = item.state || item.State || 'unknown';
+  return [typeBadge({ kind }), lifecycleBadge(state)].filter(Boolean);
+}
+
+function typeBadge(node) {
+  const kind = node.kind || 'task';
+  if (kind === 'pr') return badge('type-pr', '🔀 PR');
+  if (kind === 'issue') return badge('type-issue', '📌 issue');
+  if (kind === 'note') return badge('type-local', '📝 note');
+  return badge('type-task', '▣ task');
+}
+
+function lifecycleBadge(value) {
+  const lifecycle = String(value || 'unknown').toLowerCase();
+  if (lifecycle === 'merged') return badge('life-merged', '🟣 merged');
+  if (lifecycle === 'draft') return badge('life-draft', '🚧 draft');
+  if (lifecycle === 'open') return badge('life-open', '🟢 open');
+  if (isClosed({ state: lifecycle })) return badge('life-closed', '⚫ closed');
+  if (lifecycle === 'local') return badge('life-local', '📝 local');
+  return badge('life-unknown', '◇ unknown');
+}
+
+function reviewBadge(review) {
+  const reviewState = String(review.state || 'none').toLowerCase();
+  if (reviewState === 'approved') return badge('review-approved', `✅ review${review.approvals ? ` ${review.approvals}` : ''}`);
+  if (reviewState === 'changes_requested') return badge('review-changes', `✋ changes${review.changes_requested ? ` ${review.changes_requested}` : ''}`);
+  if (reviewState === 'requested') return badge('review-requested', '👀 review');
+  if (reviewState === 'commented') return badge('review-commented', '💬 comments');
+  return badge('review-none', '👀 no review');
+}
+
+function ciBadge(ci) {
+  const ciState = String(ci.state || 'none').toLowerCase();
+  if (ciState === 'success') return badge('ci-success', `🟢 ci ok${ci.total ? ` ${ci.total}` : ''}`);
+  if (ciState === 'failure') return badge('ci-failure', `🔴 ci fail${ci.failed ? ` ${ci.failed}` : ''}`);
+  if (ciState === 'pending') return badge('ci-pending', `🟡 ci wait${ci.pending ? ` ${ci.pending}` : ''}`);
+  return badge('ci-none', '⚪ no ci');
+}
+
+function badge(kind, text) {
+  return { kind, text };
+}
+
+function badgesHTML(badges) {
+  if (!badges || badges.length === 0) return '';
+  return `<div class="badges">${badges.map((item) => `<span class="badge ${esc(item.kind)}">${esc(item.text)}</span>`).join('')}</div>`;
+}
+
+function badgeText(badges) {
+  return (badges || []).map((item) => item.text || '').join(' ');
+}
+
+function badgeClass(value) {
+  return String(value || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown';
 }
 
 function labels(node) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.7-dev';
+const assetVersion = 'v4.1.8-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -1222,9 +1222,20 @@ function renderGraph(snapshot, nodes) {
 function renderTable(nodes) {
   const rows = nodes.map((node) => {
     const id = node.url ? `<a href="${esc(node.url)}">${esc(node.id)}</a>` : esc(node.id);
-    return `<tr class="${nodeCardClasses(node).join(' ')}"><td>${id}</td><td>${badgesHTML(nodeBadges(node))}</td><td>${esc(node.title)}</td><td>${esc(labels(node).join(', '))}</td></tr>`;
+    const klass = nodeCardClasses(node).filter(Boolean).join(' ');
+    const labelText = labels(node).join(', ');
+    return `<tr class="${klass}">
+      <td><div class="tableItem"><div class="tableItemID">${id}</div><div class="tableItemTitle">${esc(node.title)}</div></div></td>
+      <td>${badgesHTML(nodeBadges(node))}</td>
+      <td>${esc(labelText)}</td>
+    </tr>`;
   }).join('');
-  dom.table.innerHTML = `<table><thead><tr><th>ID</th><th>Signals</th><th>Title</th><th>Labels</th></tr></thead><tbody>${rows}</tbody></table>`;
+  const empty = '<tr><td colspan="3"><div class="reason">no visible cards</div></td></tr>';
+  dom.table.innerHTML = `<table class="workTable">
+    <colgroup><col class="itemCol"><col class="signalCol"><col class="labelCol"></colgroup>
+    <thead><tr><th>Item</th><th>Signals</th><th>Labels</th></tr></thead>
+    <tbody>${rows || empty}</tbody>
+  </table>`;
 }
 
 function visibleNodes(nodes) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,5 +1,7 @@
-const assetVersion = 'v4.1.0-dev';
+const assetVersion = 'v4.1.2-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
+const githubTokenStorageKey = 'depviz.githubToken';
+const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
 
 const dom = {
   input: document.getElementById('sourceInput'),
@@ -16,6 +18,10 @@ const dom = {
   graphCanvas: document.getElementById('graphCanvas'),
   table: document.getElementById('tableView'),
   githubToken: document.getElementById('githubTokenInput'),
+  connectGithub: document.getElementById('connectGithubBtn'),
+  pasteGithubToken: document.getElementById('pasteGithubTokenBtn'),
+  forgetGithubToken: document.getElementById('forgetGithubTokenBtn'),
+  githubAuthState: document.getElementById('githubAuthState'),
   hydrateGithub: document.getElementById('hydrateGithubBtn'),
   showExternal: document.getElementById('showExternal'),
   showLocal: document.getElementById('showLocal'),
@@ -51,7 +57,8 @@ function emptyExport() {
 }
 
 function boot() {
-  dom.githubToken.value = sessionStorage.getItem('depviz.githubToken') || '';
+  dom.githubToken.value = sessionStorage.getItem(githubTokenStorageKey) || '';
+  refreshGitHubAuthUI();
   wireEvents();
   const hashed = readHash();
   if (hashed) {
@@ -88,7 +95,13 @@ function wireEvents() {
   document.getElementById('shareBtn').addEventListener('click', shareLink);
   document.getElementById('exportBtn').addEventListener('click', exportJSON);
   document.getElementById('fileInput').addEventListener('change', readFile);
-  dom.githubToken.addEventListener('input', persistGitHubToken);
+  dom.connectGithub.addEventListener('click', connectGitHub);
+  dom.pasteGithubToken.addEventListener('click', pasteGitHubToken);
+  dom.forgetGithubToken.addEventListener('click', forgetGitHubToken);
+  dom.githubToken.addEventListener('input', () => {
+    persistGitHubToken();
+    refreshGitHubAuthUI();
+  });
   dom.hydrateGithub.addEventListener('click', hydrateGitHub);
 }
 
@@ -126,9 +139,92 @@ function update() {
 }
 
 function persistGitHubToken() {
-  const token = dom.githubToken.value.trim();
-  if (token) sessionStorage.setItem('depviz.githubToken', token);
-  else sessionStorage.removeItem('depviz.githubToken');
+  const token = githubToken();
+  if (token) sessionStorage.setItem(githubTokenStorageKey, token);
+  else sessionStorage.removeItem(githubTokenStorageKey);
+}
+
+function githubToken() {
+  return dom.githubToken.value.trim();
+}
+
+function setGitHubToken(token) {
+  dom.githubToken.value = token.trim();
+  persistGitHubToken();
+  refreshGitHubAuthUI();
+}
+
+function refreshGitHubAuthUI() {
+  const connected = Boolean(githubToken());
+  dom.githubAuthState.textContent = connected ? 'GitHub: token' : 'GitHub: public';
+  dom.forgetGithubToken.disabled = !connected;
+}
+
+function connectGitHub() {
+  const refs = githubRefsForSnapshot(state.data.snapshot);
+  const url = buildGitHubTokenURL(refs);
+  const popup = window.open(url, '_blank');
+  if (popup) popup.opener = null;
+  const owners = uniqueGitHubOwners(refs);
+  dom.status.textContent = owners.length > 1
+    ? `GitHub token page opened; choose access for ${owners.length} owners`
+    : 'GitHub token page opened';
+}
+
+async function pasteGitHubToken() {
+  if (!navigator.clipboard || !navigator.clipboard.readText) {
+    dom.status.textContent = 'clipboard unavailable; use token fallback';
+    dom.githubToken.focus();
+    return;
+  }
+  try {
+    const token = extractGitHubToken(await navigator.clipboard.readText());
+    if (!token) {
+      dom.status.textContent = 'clipboard has no GitHub token';
+      dom.githubToken.focus();
+      return;
+    }
+    setGitHubToken(token);
+    dom.status.textContent = 'GitHub token ready for this tab';
+  } catch (err) {
+    dom.status.textContent = 'clipboard blocked; use token fallback';
+    dom.githubToken.focus();
+  }
+}
+
+function forgetGitHubToken() {
+  setGitHubToken('');
+  dom.status.textContent = 'GitHub token forgotten';
+}
+
+function buildGitHubTokenURL(refs) {
+  const repos = [...new Set(refs.map((ref) => ref.repo))].filter(Boolean);
+  const owners = uniqueGitHubOwners(refs);
+  const description = repos.length > 0
+    ? `Read issues and pull requests for ${repos.slice(0, 6).join(', ')} from DepViz Live.`
+    : 'Read issues and pull requests from DepViz Live.';
+  const params = new URLSearchParams({
+    name: 'DepViz Live',
+    description,
+    expires_in: '30',
+    metadata: 'read',
+    issues: 'read',
+    pull_requests: 'read',
+  });
+  if (owners.length === 1) params.set('target_name', owners[0]);
+  return `${githubFineGrainedTokenURL}?${params.toString()}`;
+}
+
+function uniqueGitHubOwners(refs) {
+  return [...new Set(refs.map((ref) => ref.repo.split('/')[0]).filter(Boolean))];
+}
+
+function extractGitHubToken(text) {
+  const trimmed = String(text || '').trim();
+  const prefixed = trimmed.match(/\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+)\b/);
+  if (prefixed) return prefixed[0];
+  if (/^[A-Za-z0-9_]{20,}$/.test(trimmed)) return trimmed;
+  return '';
 }
 
 async function hydrateGitHub() {
@@ -139,10 +235,10 @@ async function hydrateGitHub() {
   }
 
   dom.hydrateGithub.disabled = true;
-  dom.status.textContent = `hydrating ${refs.length} GitHub refs`;
+  dom.status.textContent = `refreshing ${refs.length} GitHub refs`;
   dom.error.textContent = '';
   try {
-    const token = dom.githubToken.value.trim();
+    const token = githubToken();
     const updates = [];
     const failures = [];
     for (const ref of refs) {
@@ -157,8 +253,8 @@ async function hydrateGitHub() {
       render();
     }
     dom.status.textContent = failures.length > 0
-      ? `hydrated ${updates.length}/${refs.length} GitHub refs`
-      : `hydrated ${updates.length} GitHub refs`;
+      ? `refreshed ${updates.length}/${refs.length} GitHub refs`
+      : `refreshed ${updates.length} GitHub refs`;
     dom.error.textContent = failures.slice(0, 2).join('  ');
   } finally {
     dom.hydrateGithub.disabled = false;
@@ -193,7 +289,7 @@ async function fetchGitHubNode(ref, token) {
   };
   if (token) headers.Authorization = `Bearer ${token}`;
   const res = await fetch(`https://api.github.com/repos/${ref.repo}/issues/${ref.number}`, { headers });
-  if (!res.ok) throw new Error(githubFetchError(res));
+  if (!res.ok) throw new Error(githubFetchError(res, token));
   const issue = await res.json();
   const isPR = Boolean(issue.pull_request);
   const marker = ref.marker === '!' || isPR ? '!' : '#';
@@ -218,9 +314,14 @@ async function fetchGitHubNode(ref, token) {
   });
 }
 
-function githubFetchError(res) {
-  if (res.status === 401 || res.status === 403) return `${res.status}; add a token or check access`;
-  if (res.status === 404) return '404; missing or private';
+function githubFetchError(res, token) {
+  if (res.status === 401) return token ? '401; token rejected' : '401; connect GitHub';
+  if (res.status === 403) return token
+    ? '403; token lacks access or rate-limited'
+    : '403; connect GitHub for private refs or higher limits';
+  if (res.status === 404) return token
+    ? '404; missing or token lacks repo access'
+    : '404; missing/private; connect GitHub if private';
   return `${res.status} ${res.statusText}`;
 }
 

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.8-dev';
+const assetVersion = 'v4.1.9-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -34,7 +34,7 @@ const state = {
   filter: '',
   showExternal: true,
   showLocal: true,
-  showClosed: false,
+  showClosed: true,
   githubRefresh: [],
   data: emptyExport(),
 };
@@ -1177,7 +1177,8 @@ function renderItem(item) {
   const reason = esc(item.reason || item.Reason || '');
   const label = url ? `<a href="${esc(url)}">${id}</a>` : id;
   const badges = badgesHTML(item.badges || plainBadges(item));
-  return `<div class="item"><div class="itemHead"><strong>${label} ${title}</strong>${badges}</div><div class="reason">${reason}</div></div>`;
+  const klass = ['item', isClosed({ state: item.state || item.State }) ? 'closedItem' : ''].filter(Boolean).join(' ');
+  return `<div class="${klass}"><div class="itemHead"><strong>${label} ${title}</strong>${badges}</div><div class="reason">${reason}</div></div>`;
 }
 
 function renderGraph(snapshot, nodes) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.8-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.9-dev">
 </head>
 <body>
   <header class="topbar">
@@ -63,7 +63,7 @@
         <input id="filterInput" type="search" placeholder="Filter id, title, state, label" aria-label="Filter cards">
         <label><input id="showExternal" type="checkbox" checked> External</label>
         <label><input id="showLocal" type="checkbox" checked> Local</label>
-        <label><input id="showClosed" type="checkbox"> Closed</label>
+        <label><input id="showClosed" type="checkbox" checked> Closed</label>
       </div>
 
       <div class="stats" id="stats"></div>
@@ -75,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.8-dev"></script>
+  <script src="./app.js?v=v4.1.9-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.7-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.8-dev">
 </head>
 <body>
   <header class="topbar">
@@ -75,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.7-dev"></script>
+  <script src="./app.js?v=v4.1.8-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="./style.css?v=v4.1.7-dev">
 </head>
 <body>
   <header class="topbar">
@@ -75,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.5-dev"></script>
+  <script src="./app.js?v=v4.1.7-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -75,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.4-dev"></script>
+  <script src="./app.js?v=v4.1.5-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -13,8 +13,14 @@
       <span id="status">stateless work graph</span>
     </div>
     <div class="actions">
-      <input id="githubTokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="GitHub token">
-      <button id="hydrateGithubBtn" type="button">Hydrate GitHub</button>
+      <div class="githubAuth" aria-label="GitHub connection">
+        <button id="connectGithubBtn" type="button">Connect GitHub</button>
+        <button id="pasteGithubTokenBtn" type="button">Use copied token</button>
+        <input id="githubTokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="token fallback" aria-label="GitHub token">
+        <button id="forgetGithubTokenBtn" type="button">Forget</button>
+        <span id="githubAuthState" class="tokenState">GitHub: public</span>
+      </div>
+      <button id="hydrateGithubBtn" type="button">Refresh GitHub</button>
       <button id="sampleBtn" type="button">Load sample</button>
       <button id="shareBtn" type="button">Share link</button>
       <button id="exportBtn" type="button">Export JSON</button>
@@ -69,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.0-dev"></script>
+  <script src="./app.js?v=v4.1.2-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -75,6 +75,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.2-dev"></script>
+  <script src="./app.js?v=v4.1.4-dev"></script>
 </body>
 </html>

--- a/live/app/sample.depviz
+++ b/live/app/sample.depviz
@@ -1,5 +1,5 @@
 // Standalone Live demo: define nodes by hand so cards have titles and states.
-// Click Hydrate GitHub to refresh public refs directly from api.github.com.
+// Click Refresh GitHub to refresh public refs directly from api.github.com.
 board "DepViz v4 POC"
 
 repo moul/depviz

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -371,6 +371,14 @@ textarea::selection {
   overflow-wrap: anywhere;
 }
 
+.itemHead {
+  display: block;
+}
+
+.itemHead .badges {
+  margin-top: 5px;
+}
+
 .item a {
   color: var(--blue);
   text-decoration: none;
@@ -378,6 +386,91 @@ textarea::selection {
 
 .reason {
   color: var(--muted);
+}
+
+.badges {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  border: 1px solid #d0d5dd;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #344054;
+  padding: 2px 7px;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.badge.type-pr {
+  border-color: #c4b5fd;
+  background: #f5f3ff;
+  color: #5b21b6;
+}
+
+.badge.type-issue {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.badge.type-local,
+.badge.life-local {
+  border-color: #99f6e4;
+  background: #ecfeff;
+  color: #0f766e;
+}
+
+.badge.life-open,
+.badge.review-approved,
+.badge.ci-success {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.badge.life-merged {
+  border-color: #ddd6fe;
+  background: #faf5ff;
+  color: #6d28d9;
+}
+
+.badge.life-closed,
+.badge.ci-none,
+.badge.review-none {
+  border-color: #e5e7eb;
+  background: #f9fafb;
+  color: #667085;
+}
+
+.badge.life-draft,
+.badge.review-requested,
+.badge.review-commented,
+.badge.ci-pending {
+  border-color: #fde68a;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.badge.review-changes,
+.badge.ci-failure {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.badge.auth-public {
+  border-color: #bae6fd;
+  background: #f0f9ff;
+  color: #075985;
 }
 
 .graphCanvas {
@@ -432,6 +525,40 @@ textarea::selection {
   background: #f3f4f6;
 }
 
+.nodeCard.kind-pr {
+  border-top: 3px solid #8b5cf6;
+}
+
+.nodeCard.kind-issue {
+  border-top: 3px solid #3b82f6;
+}
+
+.nodeCard.life-merged {
+  background: #faf5ff;
+  border-color: #c4b5fd;
+}
+
+.nodeCard.life-draft {
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.nodeCard.ci-failure {
+  box-shadow: inset 3px 0 0 #dc2626, 0 2px 12px rgba(16, 24, 40, 0.07);
+}
+
+.nodeCard.ci-success {
+  box-shadow: inset 3px 0 0 #16a34a, 0 2px 12px rgba(16, 24, 40, 0.07);
+}
+
+tr.ci-failure td:first-child {
+  box-shadow: inset 3px 0 0 #dc2626;
+}
+
+tr.ci-success td:first-child {
+  box-shadow: inset 3px 0 0 #16a34a;
+}
+
 .nodeId {
   color: var(--muted);
   font-size: 12px;
@@ -444,6 +571,7 @@ textarea::selection {
 .nodeTitle {
   font-weight: 650;
   overflow-wrap: anywhere;
+  margin-bottom: 8px;
 }
 
 .nodeState {
@@ -484,6 +612,10 @@ tr:last-child td {
   border-bottom: 0;
 }
 
+td .badges {
+  max-width: 320px;
+}
+
 @media (max-width: 920px) {
   .shell {
     grid-template-columns: 1fr;
@@ -506,6 +638,7 @@ tr:last-child td {
   .briefGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
 }
 
 @media (max-width: 560px) {

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -75,6 +75,7 @@ button:disabled {
 
 .brand strong {
   font-size: 17px;
+  white-space: nowrap;
 }
 
 .brand span,
@@ -92,6 +93,13 @@ button:disabled {
   gap: 8px;
 }
 
+.githubAuth {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 .actions input {
   width: 178px;
   border: 1px solid var(--line);
@@ -99,6 +107,17 @@ button:disabled {
   background: var(--panel);
   color: var(--ink);
   padding: 7px 9px;
+}
+
+.githubAuth input {
+  width: 126px;
+}
+
+.tokenState {
+  min-width: 96px;
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .actions input:focus {

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -366,6 +366,49 @@ textarea::selection {
   border-top: 0;
 }
 
+.item.closedItem {
+  margin-top: 5px;
+  padding: 5px 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #f5f6f8;
+  color: #667085;
+  font-size: 12px;
+}
+
+.item.closedItem .itemHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.item.closedItem strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item.closedItem .badges {
+  flex: 0 0 auto;
+  margin-top: 0;
+}
+
+.item.closedItem .badge {
+  min-height: 17px;
+  padding: 1px 5px;
+  font-size: 10px;
+}
+
+.item.closedItem .badge.review-none {
+  display: none;
+}
+
+.item.closedItem .reason {
+  display: none;
+}
+
 .item strong {
   display: block;
   overflow-wrap: anywhere;
@@ -523,6 +566,12 @@ textarea::selection {
 .nodeCard.closed {
   color: #6b7280;
   background: #f3f4f6;
+  width: 190px;
+  min-height: 0;
+  max-height: 64px;
+  overflow: hidden;
+  padding: 7px 8px;
+  opacity: 0.82;
 }
 
 .nodeCard.kind-pr {
@@ -541,6 +590,12 @@ textarea::selection {
 .nodeCard.life-draft {
   background: #fffbeb;
   border-color: #fde68a;
+}
+
+.nodeCard.closed.life-closed,
+.nodeCard.closed.life-merged {
+  background: #f3f4f6;
+  border-color: #d1d5db;
 }
 
 .nodeCard.ci-failure {
@@ -572,6 +627,39 @@ tr.ci-success td:first-child {
   font-weight: 650;
   overflow-wrap: anywhere;
   margin-bottom: 8px;
+}
+
+.nodeCard.closed .nodeId,
+.nodeCard.closed .nodeTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nodeCard.closed .nodeId {
+  display: none;
+}
+
+.nodeCard.closed .nodeTitle {
+  margin-bottom: 5px;
+  font-size: 12px;
+}
+
+.nodeCard.closed .badge {
+  flex: 0 0 auto;
+  min-height: 17px;
+  padding: 1px 5px;
+  font-size: 10px;
+}
+
+.nodeCard.closed .badges {
+  flex-wrap: nowrap;
+  gap: 3px;
+  overflow: hidden;
+}
+
+.nodeCard.closed .badge.review-none {
+  display: none;
 }
 
 .nodeState {
@@ -611,6 +699,54 @@ td {
 
 tr:last-child td {
   border-bottom: 0;
+}
+
+.workTable tr.closed td {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  background: #f5f6f8;
+  color: #667085;
+  font-size: 12px;
+}
+
+.workTable tr.closed .tableItem {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.workTable tr.closed .tableItemID,
+.workTable tr.closed .tableItemTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workTable tr.closed .tableItemID {
+  flex: 0 1 46%;
+  margin-bottom: 0;
+}
+
+.workTable tr.closed .tableItemTitle {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.workTable tr.closed .badges {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.workTable tr.closed .badge {
+  min-height: 17px;
+  padding: 1px 5px;
+  font-size: 10px;
+}
+
+.workTable tr.closed .badge.review-none {
+  display: none;
 }
 
 .itemCol {

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -582,6 +582,7 @@ tr.ci-success td:first-child {
 
 table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -612,8 +613,39 @@ tr:last-child td {
   border-bottom: 0;
 }
 
-td .badges {
-  max-width: 320px;
+.itemCol {
+  width: 42%;
+}
+
+.signalCol {
+  width: 42%;
+}
+
+.labelCol {
+  width: 16%;
+}
+
+.tableItem {
+  min-width: 0;
+}
+
+.tableItemID {
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+
+.tableItemID a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.tableItemTitle {
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.workTable .badges {
+  max-width: 100%;
 }
 
 @media (max-width: 920px) {


### PR DESCRIPTION
## Summary
- add a backendless Connect GitHub flow that opens GitHub's prefilled fine-grained token form
- add Use copied token / Forget controls with session-only token storage
- rename the UI action to Refresh GitHub and improve auth/access errors
- surface refreshed refs in Brief even when closed cards are hidden, so relation-only refs like #683 visibly resolve titles
- persist the current Live view in the URL with `?view=graph|table` while preserving `#data=...`
- hydrate PR metadata from GitHub: lifecycle, reviews, check runs, and commit statuses
- show compact signal badges across Brief, Graph, and Table for PR/issue type, open/closed/merged/draft, review, and CI
- show Closed by default, with closed cards rendered as compact gray archive rows/cards
- stabilize Table rows so refresh + Closed toggle does not reflow badly: Item/Signals/Labels fixed layout, ID and title grouped
- fall back to public GitHub reads when a scoped token fails on a public ref
- fix base64url padding for share-link input hashes

## Verification
- node --check live/app/app.js
- go test ./...
- go vet ./...
- git diff --check
- Browser check: Connect GitHub URL includes metadata=read, issues=read, pull_requests=read, checks=read, statuses=read, expires_in=30, target_name=moul; Use copied token and Forget update UI; public Refresh GitHub works
- Browser regression: `repo moul/depviz` + `#683 depends on local` refreshes to `gh:moul/depviz#683 chore: bump dependencies`
- Browser bookmark: `?view=graph#data=...` reloads directly into Graph and keeps the flow payload
- Browser signals: `#684` shows `🔀 PR`, `🟢 open`, `👀 no review`, `🟢 ci ok`; `#683` shows `🔀 PR`, `🟣 merged`, `🟢 ci ok`
- Browser table: in `view=table`, Closed is checked by default; after Refresh GitHub, `#683` is visible as a compact gray single-line row with merged/CI badges
- Browser graph/brief: closed cards/items are gray, muted, compact, and hide low-value `no review` noise
