### PR TITLE
feat: make graph edges selectable

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -106,6 +106,7 @@ function wireEvents() {
   });
   dom.hydrateGithub.addEventListener('click', hydrateGitHub);
   dom.suggestions.addEventListener('click', handleSuggestionClick);
+  dom.graphCanvas.addEventListener('click', handleGraphClick);
 }
 
 async function loadSample() {
@@ -1208,11 +1209,13 @@ function renderGraph(snapshot, nodes) {
     const to = positions.get(edge.to_id);
     if (!from || !to) continue;
     const soft = isSoftEdge(edge);
-    const selected = edge.id === state.selectedEdgeID;
+    const edgeID = edgeSelectionID(edge);
+    const selected = edgeID === state.selectedEdgeID;
     const kind = esc(edge.kind || 'edge');
     const authority = esc(edge.authority || '');
     const line = graphEdgeLine(from, to);
-    html += `<line class="${edgeClasses(edge)}${selected ? ' selectedEdge' : ''}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" marker-end="url(#${selected ? 'arrowSelected' : (soft ? 'arrowSoft' : 'arrowHard')})"><title>${kind}${authority ? ` - ${authority}` : ''}</title></line>`;
+    html += `<line class="graphEdgeHit" data-edge-id="${esc(edgeID)}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}"></line>`;
+    html += `<line class="${edgeClasses(edge)}${selected ? ' selectedEdge' : ''}" data-edge-id="${esc(edgeID)}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" marker-end="url(#${selected ? 'arrowSelected' : (soft ? 'arrowSoft' : 'arrowHard')})"><title>${kind}${authority ? ` - ${authority}` : ''}</title></line>`;
   }
   html += '</svg>';
   for (const node of nodes) {
@@ -1227,6 +1230,16 @@ function renderGraph(snapshot, nodes) {
   }
   html += '</div>';
   dom.graphCanvas.innerHTML = html;
+}
+
+function handleGraphClick(event) {
+  const target = event.target.closest?.('[data-edge-id]');
+  if (!target || !dom.graphCanvas.contains(target)) return;
+  const edgeID = target.dataset.edgeId || '';
+  if (!edgeByID(edgeID)) return;
+  state.selectedEdgeID = edgeID;
+  render();
+  dom.status.textContent = 'edge selected';
 }
 
 function graphLayout(snapshot, nodes) {
@@ -1621,7 +1634,11 @@ function edgeBlockedAndBlockerRaw(edge) {
 }
 
 function edgeByID(edgeID) {
-  return (state.data.snapshot.edges || []).find((edge) => edge.id === edgeID);
+  return (state.data.snapshot.edges || []).find((edge) => edgeSelectionID(edge) === edgeID);
+}
+
+function edgeSelectionID(edge) {
+  return edge.id || relationSignature(edge);
 }
 
 function relationLabel(kind) {

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -641,10 +641,12 @@ textarea::selection {
   position: absolute;
   inset: 0;
   overflow: visible;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .graphEdge {
+  cursor: pointer;
+  pointer-events: stroke;
   stroke: #667085;
   stroke-width: 1.7;
 }
@@ -659,6 +661,13 @@ textarea::selection {
   stroke: #dc2626;
   stroke-width: 3;
   stroke-dasharray: none;
+}
+
+.graphEdgeHit {
+  cursor: pointer;
+  pointer-events: stroke;
+  stroke: rgba(15, 118, 110, 0.01);
+  stroke-width: 16;
 }
 
 .graphEdge.edge-addresses,


### PR DESCRIPTION
## Summary
- make graph edges selectable with a wider invisible hit target
- highlight the selected edge and its endpoint cards
- keep this as the smallest standalone interaction layer before adding an inspector

## Manual QA
Fast path after the PR preview publishes:
1. Open: https://moul.github.io/depviz/previews/pr-688/live/?view=graph#data=Ym9hcmQgIkVkZ2Ugc2VsZWN0IgpyZXBvIG1vdWwvZGVwdml6CgojMSAiQmFzZSIgW29wZW5dCiMyICJNaWRkbGUiIFtvcGVuXQojMiBkZXBlbmRzIG9uICMxCg
2. Click the edge between `#1 Base` and `#2 Middle`.
3. Expected: the edge turns red, both endpoint cards get a red outline, and the header status says `edge selected`.

Local path:
1. Run `make live`.
2. Open `http://127.0.0.1:8686/?view=graph`.
3. Paste:

```depviz
board "Edge select"
repo moul/depviz

#1 "Base" [open]
#2 "Middle" [open]
#2 depends on #1
```

Then click the edge and check the same expected highlight.

## Verification
- `make test`
- `node --check live/app/app.js`
- headless Chrome smoke: coordinate click at edge midpoint selects one edge and highlights two endpoints
