### PR TITLE
feat: show selected edge inspector

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -15,6 +15,7 @@ const dom = {
   filter: document.getElementById('filterInput'),
   stats: document.getElementById('stats'),
   suggestions: document.getElementById('suggestionPanel'),
+  edgeInspector: document.getElementById('edgeInspector'),
   brief: document.getElementById('briefView'),
   graph: document.getElementById('graphView'),
   graphCanvas: document.getElementById('graphCanvas'),
@@ -106,6 +107,7 @@ function wireEvents() {
   });
   dom.hydrateGithub.addEventListener('click', hydrateGitHub);
   dom.suggestions.addEventListener('click', handleSuggestionClick);
+  dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
 }
 
@@ -1140,6 +1142,7 @@ function render() {
   dom.boardMeta.textContent = `${snapshot.nodes.length} nodes - ${snapshot.edges.length} edges`;
   renderStats(brief.counts || {}, snapshot);
   renderSuggestions(snapshot);
+  renderEdgeInspector(snapshot);
   dom.brief.classList.toggle('hidden', state.view !== 'brief');
   dom.graph.classList.toggle('hidden', state.view !== 'graph');
   dom.table.classList.toggle('hidden', state.view !== 'table');
@@ -1446,6 +1449,60 @@ function renderSuggestion(edge, nodes) {
       <button type="button" data-suggestion-action="dismiss" data-edge-id="${esc(edge.id)}">Hide</button>
     </div>
   </article>`;
+}
+
+function renderEdgeInspector(snapshot) {
+  const edge = edgeByID(state.selectedEdgeID);
+  dom.edgeInspector.classList.toggle('hidden', !edge);
+  if (!edge) {
+    dom.edgeInspector.innerHTML = '';
+    return;
+  }
+  const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const from = nodes.get(edge.from_id) || placeholderNode(edge.from_id);
+  const to = nodes.get(edge.to_id) || placeholderNode(edge.to_id);
+  const evidence = parseEvidence(edge);
+  const evidenceLine = evidenceText(edge);
+  const evidenceJSON = Object.keys(evidence).length ? JSON.stringify(evidence, null, 2) : '';
+  const confidence = confidenceLabel(edge);
+  const authority = edge.authority || 'local';
+  dom.edgeInspector.innerHTML = `<section class="edgeBox" aria-label="Selected edge">
+    <div class="edgeHead">
+      <div>
+        <strong>Selected edge</strong>
+        <span>${esc(relationLabel(edge.kind))}</span>
+      </div>
+      <button type="button" data-edge-action="clear">Clear</button>
+    </div>
+    <div class="edgeRoute">
+      <div class="edgeEndpoint">
+        <span>From</span>
+        <strong>${esc(shortNodeLabel(from))}</strong>
+      </div>
+      <div class="edgeArrow">${esc(relationLabel(edge.kind))}</div>
+      <div class="edgeEndpoint">
+        <span>To</span>
+        <strong>${esc(shortNodeLabel(to))}</strong>
+      </div>
+    </div>
+    <div class="edgeSignals">
+      <span class="badge edgeBadge">${esc(authority)}</span>
+      <span class="badge edgeBadge">${esc(confidence)}</span>
+      <span class="badge edgeBadge">${isSoftEdge(edge) ? 'soft' : 'official'}</span>
+    </div>
+    ${evidenceLine ? `<div class="edgeEvidence"><span>Evidence</span><code>${esc(evidenceLine)}</code></div>` : ''}
+    ${evidenceJSON ? `<details class="edgeJSON"><summary>Raw evidence</summary><pre>${esc(evidenceJSON)}</pre></details>` : ''}
+  </section>`;
+}
+
+function handleEdgeInspectorClick(event) {
+  const button = event.target.closest('[data-edge-action]');
+  if (!button) return;
+  if (button.dataset.edgeAction === 'clear') {
+    state.selectedEdgeID = '';
+    render();
+    dom.status.textContent = 'edge selection cleared';
+  }
 }
 
 function handleSuggestionClick(event) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -68,6 +68,7 @@
 
       <div class="stats" id="stats"></div>
       <div id="suggestionPanel" class="suggestionPanel hidden"></div>
+      <div id="edgeInspector" class="edgeInspector hidden"></div>
       <div id="briefView" class="view"></div>
       <div id="graphView" class="view hidden">
         <div id="graphCanvas" class="graphCanvas"></div>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -621,6 +621,116 @@ textarea::selection {
   margin-top: 7px;
 }
 
+.edgeInspector {
+  min-width: 0;
+}
+
+.edgeBox {
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 10px;
+}
+
+.edgeHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.edgeHead strong {
+  display: block;
+}
+
+.edgeHead span,
+.edgeEndpoint span,
+.edgeEvidence span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.edgeRoute {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.edgeEndpoint {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #ffffff;
+  padding: 8px;
+}
+
+.edgeEndpoint strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edgeArrow {
+  color: #3730a3;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.edgeSignals {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.edgeBadge {
+  border-color: #c7d2fe;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.edgeEvidence {
+  display: grid;
+  gap: 3px;
+  margin-top: 8px;
+}
+
+.edgeEvidence code {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #344054;
+  padding: 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edgeJSON {
+  margin-top: 7px;
+}
+
+.edgeJSON summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.edgeJSON pre {
+  max-height: 180px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  padding: 8px;
+}
+
 .graphCanvas {
   position: relative;
   min-width: 900px;
@@ -958,6 +1068,10 @@ tr:last-child td {
   .suggestionMeta,
   .suggestionActions {
     justify-content: flex-start;
+  }
+
+  .edgeRoute {
+    grid-template-columns: 1fr;
   }
 
 }


### PR DESCRIPTION
## Summary
- add a read-only Selected edge inspector below Suggested relations
- show endpoints, relation kind, authority, confidence, official/soft status, and captured evidence
- add a Clear action to remove the current selection

## Stack
This is step 2 of the edge inspector loop and is based on #688. Review #690 for the full combined loop with a Pages preview.

## Manual QA
Stacked PR note: because this PR targets #688 instead of `master`, the Pages preview may not publish. Use the local path below, or use #690 to test the full UI in the browser.

Local path:
1. Run `make live`.
2. Open `http://127.0.0.1:8686/?view=graph`.
3. Paste:

```depviz
board "Edge select"
repo moul/depviz

#1 "Base" [open]
#2 "Middle" [open]
#2 depends on #1
```

4. Click the edge between `#1 Base` and `#2 Middle`.
5. Expected: the edge and endpoint cards are highlighted.
6. Expected: a Selected edge panel appears above the graph.
7. Expected: the panel shows From `#1 Base`, To `#2 Middle`, confidence `100%`, status `official`, and evidence `#2 depends on #1`.
8. Click Clear.
9. Expected: the panel disappears and the edge highlight clears.

## Verification
- `make test`
- `node --check live/app/app.js`
- headless Chrome smoke: click edge opens inspector with endpoints/evidence, Clear hides it
