### PR TITLE
feat: add live edge inspector workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ highlights the edge and its endpoints in the graph; `Promote` writes an official
 local relation back into the current input, so the decision survives share links
 and exports.
 
+Graph edges are selectable. Selecting one opens an edge inspector with endpoints,
+authority, confidence, soft/official status, and captured evidence. Suggested
+edges can be promoted or hidden from the inspector as well as from the suggestions
+panel.
+
 The graph view uses relation-aware placement: connected cards are arranged by
 dependency direction, while unrelated visible cards are kept in a compact pool.
 This keeps realistic imports, such as a hundred recent GitHub issues and PRs,

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -15,6 +15,7 @@ const dom = {
   filter: document.getElementById('filterInput'),
   stats: document.getElementById('stats'),
   suggestions: document.getElementById('suggestionPanel'),
+  edgeInspector: document.getElementById('edgeInspector'),
   brief: document.getElementById('briefView'),
   graph: document.getElementById('graphView'),
   graphCanvas: document.getElementById('graphCanvas'),
@@ -106,6 +107,7 @@ function wireEvents() {
   });
   dom.hydrateGithub.addEventListener('click', hydrateGitHub);
   dom.suggestions.addEventListener('click', handleSuggestionClick);
+  dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
 }
 
@@ -1140,6 +1142,7 @@ function render() {
   dom.boardMeta.textContent = `${snapshot.nodes.length} nodes - ${snapshot.edges.length} edges`;
   renderStats(brief.counts || {}, snapshot);
   renderSuggestions(snapshot);
+  renderEdgeInspector(snapshot);
   dom.brief.classList.toggle('hidden', state.view !== 'brief');
   dom.graph.classList.toggle('hidden', state.view !== 'graph');
   dom.table.classList.toggle('hidden', state.view !== 'table');
@@ -1446,6 +1449,60 @@ function renderSuggestion(edge, nodes) {
       <button type="button" data-suggestion-action="dismiss" data-edge-id="${esc(edge.id)}">Hide</button>
     </div>
   </article>`;
+}
+
+function renderEdgeInspector(snapshot) {
+  const edge = edgeByID(state.selectedEdgeID);
+  dom.edgeInspector.classList.toggle('hidden', !edge);
+  if (!edge) {
+    dom.edgeInspector.innerHTML = '';
+    return;
+  }
+  const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const from = nodes.get(edge.from_id) || placeholderNode(edge.from_id);
+  const to = nodes.get(edge.to_id) || placeholderNode(edge.to_id);
+  const evidence = parseEvidence(edge);
+  const evidenceLine = evidenceText(edge);
+  const evidenceJSON = Object.keys(evidence).length ? JSON.stringify(evidence, null, 2) : '';
+  const confidence = confidenceLabel(edge);
+  const authority = edge.authority || 'local';
+  dom.edgeInspector.innerHTML = `<section class="edgeBox" aria-label="Selected edge">
+    <div class="edgeHead">
+      <div>
+        <strong>Selected edge</strong>
+        <span>${esc(relationLabel(edge.kind))}</span>
+      </div>
+      <button type="button" data-edge-action="clear">Clear</button>
+    </div>
+    <div class="edgeRoute">
+      <div class="edgeEndpoint">
+        <span>From</span>
+        <strong>${esc(shortNodeLabel(from))}</strong>
+      </div>
+      <div class="edgeArrow">${esc(relationLabel(edge.kind))}</div>
+      <div class="edgeEndpoint">
+        <span>To</span>
+        <strong>${esc(shortNodeLabel(to))}</strong>
+      </div>
+    </div>
+    <div class="edgeSignals">
+      <span class="badge edgeBadge">${esc(authority)}</span>
+      <span class="badge edgeBadge">${esc(confidence)}</span>
+      <span class="badge edgeBadge">${isSoftEdge(edge) ? 'soft' : 'official'}</span>
+    </div>
+    ${evidenceLine ? `<div class="edgeEvidence"><span>Evidence</span><code>${esc(evidenceLine)}</code></div>` : ''}
+    ${evidenceJSON ? `<details class="edgeJSON"><summary>Raw evidence</summary><pre>${esc(evidenceJSON)}</pre></details>` : ''}
+  </section>`;
+}
+
+function handleEdgeInspectorClick(event) {
+  const button = event.target.closest('[data-edge-action]');
+  if (!button) return;
+  if (button.dataset.edgeAction === 'clear') {
+    state.selectedEdgeID = '';
+    render();
+    dom.status.textContent = 'edge selection cleared';
+  }
 }
 
 function handleSuggestionClick(event) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1405,7 +1405,7 @@ function renderTable(nodes) {
 
 function renderSuggestions(snapshot) {
   const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
-  const suggestions = suggestedEdges(snapshot).filter((edge) => !state.dismissedSuggestionIDs.has(edge.id));
+  const suggestions = suggestedEdges(snapshot).filter((edge) => !state.dismissedSuggestionIDs.has(edgeSelectionID(edge)));
   dom.suggestions.classList.toggle('hidden', suggestions.length === 0);
   if (suggestions.length === 0) {
     dom.suggestions.innerHTML = '';
@@ -1426,7 +1426,8 @@ function renderSuggestions(snapshot) {
 function renderSuggestion(edge, nodes) {
   const from = nodes.get(edge.from_id) || placeholderNode(edge.from_id);
   const to = nodes.get(edge.to_id) || placeholderNode(edge.to_id);
-  const selected = edge.id === state.selectedEdgeID;
+  const edgeID = edgeSelectionID(edge);
+  const selected = edgeID === state.selectedEdgeID;
   const evidence = evidenceText(edge);
   const kind = relationLabel(edge.kind);
   const confidence = confidenceLabel(edge);
@@ -1444,9 +1445,9 @@ function renderSuggestion(edge, nodes) {
       <span class="badge suggestionBadge">${esc(edge.authority || 'soft')}</span>
     </div>
     <div class="suggestionActions">
-      <button type="button" data-suggestion-action="focus" data-edge-id="${esc(edge.id)}">Focus</button>
-      <button type="button" class="primaryAction" data-suggestion-action="promote" data-edge-id="${esc(edge.id)}">Promote</button>
-      <button type="button" data-suggestion-action="dismiss" data-edge-id="${esc(edge.id)}">Hide</button>
+      <button type="button" data-suggestion-action="focus" data-edge-id="${esc(edgeID)}">Focus</button>
+      <button type="button" class="primaryAction" data-suggestion-action="promote" data-edge-id="${esc(edgeID)}">Promote</button>
+      <button type="button" data-suggestion-action="dismiss" data-edge-id="${esc(edgeID)}">Hide</button>
     </div>
   </article>`;
 }
@@ -1466,13 +1467,21 @@ function renderEdgeInspector(snapshot) {
   const evidenceJSON = Object.keys(evidence).length ? JSON.stringify(evidence, null, 2) : '';
   const confidence = confidenceLabel(edge);
   const authority = edge.authority || 'local';
+  const suggested = isSuggestedEdge(edge) && !hasOfficialEquivalent(snapshot, edge);
+  const suggestionActions = suggested
+    ? `<button type="button" class="primaryAction" data-edge-action="promote">Promote</button>
+      <button type="button" data-edge-action="hide">Hide suggestion</button>`
+    : '';
   dom.edgeInspector.innerHTML = `<section class="edgeBox" aria-label="Selected edge">
     <div class="edgeHead">
       <div>
         <strong>Selected edge</strong>
         <span>${esc(relationLabel(edge.kind))}</span>
       </div>
-      <button type="button" data-edge-action="clear">Clear</button>
+      <div class="edgeActions">
+        ${suggestionActions}
+        <button type="button" data-edge-action="clear">Clear</button>
+      </div>
     </div>
     <div class="edgeRoute">
       <div class="edgeEndpoint">
@@ -1498,11 +1507,14 @@ function renderEdgeInspector(snapshot) {
 function handleEdgeInspectorClick(event) {
   const button = event.target.closest('[data-edge-action]');
   if (!button) return;
+  const edgeID = state.selectedEdgeID;
   if (button.dataset.edgeAction === 'clear') {
     state.selectedEdgeID = '';
     render();
     dom.status.textContent = 'edge selection cleared';
   }
+  if (button.dataset.edgeAction === 'promote') promoteSuggestedEdge(edgeID);
+  if (button.dataset.edgeAction === 'hide') dismissSuggestedEdge(edgeID);
 }
 
 function handleSuggestionClick(event) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -106,6 +106,7 @@ function wireEvents() {
   });
   dom.hydrateGithub.addEventListener('click', hydrateGitHub);
   dom.suggestions.addEventListener('click', handleSuggestionClick);
+  dom.graphCanvas.addEventListener('click', handleGraphClick);
 }
 
 async function loadSample() {
@@ -1208,11 +1209,13 @@ function renderGraph(snapshot, nodes) {
     const to = positions.get(edge.to_id);
     if (!from || !to) continue;
     const soft = isSoftEdge(edge);
-    const selected = edge.id === state.selectedEdgeID;
+    const edgeID = edgeSelectionID(edge);
+    const selected = edgeID === state.selectedEdgeID;
     const kind = esc(edge.kind || 'edge');
     const authority = esc(edge.authority || '');
     const line = graphEdgeLine(from, to);
-    html += `<line class="${edgeClasses(edge)}${selected ? ' selectedEdge' : ''}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" marker-end="url(#${selected ? 'arrowSelected' : (soft ? 'arrowSoft' : 'arrowHard')})"><title>${kind}${authority ? ` - ${authority}` : ''}</title></line>`;
+    html += `<line class="graphEdgeHit" data-edge-id="${esc(edgeID)}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}"></line>`;
+    html += `<line class="${edgeClasses(edge)}${selected ? ' selectedEdge' : ''}" data-edge-id="${esc(edgeID)}" x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" marker-end="url(#${selected ? 'arrowSelected' : (soft ? 'arrowSoft' : 'arrowHard')})"><title>${kind}${authority ? ` - ${authority}` : ''}</title></line>`;
   }
   html += '</svg>';
   for (const node of nodes) {
@@ -1227,6 +1230,16 @@ function renderGraph(snapshot, nodes) {
   }
   html += '</div>';
   dom.graphCanvas.innerHTML = html;
+}
+
+function handleGraphClick(event) {
+  const target = event.target.closest?.('[data-edge-id]');
+  if (!target || !dom.graphCanvas.contains(target)) return;
+  const edgeID = target.dataset.edgeId || '';
+  if (!edgeByID(edgeID)) return;
+  state.selectedEdgeID = edgeID;
+  render();
+  dom.status.textContent = 'edge selected';
 }
 
 function graphLayout(snapshot, nodes) {
@@ -1621,7 +1634,11 @@ function edgeBlockedAndBlockerRaw(edge) {
 }
 
 function edgeByID(edgeID) {
-  return (state.data.snapshot.edges || []).find((edge) => edge.id === edgeID);
+  return (state.data.snapshot.edges || []).find((edge) => edgeSelectionID(edge) === edgeID);
+}
+
+function edgeSelectionID(edge) {
+  return edge.id || relationSignature(edge);
 }
 
 function relationLabel(kind) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -68,6 +68,7 @@
 
       <div class="stats" id="stats"></div>
       <div id="suggestionPanel" class="suggestionPanel hidden"></div>
+      <div id="edgeInspector" class="edgeInspector hidden"></div>
       <div id="briefView" class="view"></div>
       <div id="graphView" class="view hidden">
         <div id="graphCanvas" class="graphCanvas"></div>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -621,6 +621,116 @@ textarea::selection {
   margin-top: 7px;
 }
 
+.edgeInspector {
+  min-width: 0;
+}
+
+.edgeBox {
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 10px;
+}
+
+.edgeHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.edgeHead strong {
+  display: block;
+}
+
+.edgeHead span,
+.edgeEndpoint span,
+.edgeEvidence span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.edgeRoute {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.edgeEndpoint {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #ffffff;
+  padding: 8px;
+}
+
+.edgeEndpoint strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edgeArrow {
+  color: #3730a3;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.edgeSignals {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.edgeBadge {
+  border-color: #c7d2fe;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.edgeEvidence {
+  display: grid;
+  gap: 3px;
+  margin-top: 8px;
+}
+
+.edgeEvidence code {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #344054;
+  padding: 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edgeJSON {
+  margin-top: 7px;
+}
+
+.edgeJSON summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.edgeJSON pre {
+  max-height: 180px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  padding: 8px;
+}
+
 .graphCanvas {
   position: relative;
   min-width: 900px;
@@ -958,6 +1068,10 @@ tr:last-child td {
   .suggestionMeta,
   .suggestionActions {
     justify-content: flex-start;
+  }
+
+  .edgeRoute {
+    grid-template-columns: 1fr;
   }
 
 }

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -644,6 +644,14 @@ textarea::selection {
   display: block;
 }
 
+.edgeActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
 .edgeHead span,
 .edgeEndpoint span,
 .edgeEvidence span {

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -641,10 +641,12 @@ textarea::selection {
   position: absolute;
   inset: 0;
   overflow: visible;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .graphEdge {
+  cursor: pointer;
+  pointer-events: stroke;
   stroke: #667085;
   stroke-width: 1.7;
 }
@@ -659,6 +661,13 @@ textarea::selection {
   stroke: #dc2626;
   stroke-width: 3;
   stroke-dasharray: none;
+}
+
+.graphEdgeHit {
+  cursor: pointer;
+  pointer-events: stroke;
+  stroke: rgba(15, 118, 110, 0.01);
+  stroke-width: 16;
 }
 
 .graphEdge.edge-addresses,

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -69,3 +69,33 @@ func TestLiveAssetsExposeRelationAwareGraphLayout(t *testing.T) {
 		}
 	}
 }
+
+func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
+	fsys := AppFS()
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	style, err := fs.ReadFile(fsys, "style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"inspector mount", string(index), `id="edgeInspector"`},
+		{"edge hit target", string(app), `class="graphEdgeHit"`},
+		{"inspector promote", string(app), `data-edge-action="promote"`},
+		{"edge actions", string(style), `.edgeActions`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- make graph edges selectable and highlight selected endpoints
- add a Selected edge inspector with endpoints, authority, confidence, official/soft state, and evidence
- let suggested soft edges be promoted or hidden directly from the inspector
- document the workflow and add static asset coverage

## Stack
This is step 3 of the loop and is the full-review PR. It includes:
- #688: selectable graph edges
- #689: read-only selected edge inspector
- this PR: inspector actions, docs, and tests

Review this PR if you want the full result. Review #688 or #689 if you want to comment on one step precisely.

## Manual QA
Fast path after the PR preview publishes:
1. Open: https://moul.github.io/depviz/previews/pr-690/live/?v=pr690&view=graph#data=Ym9hcmQgIkVkZ2Ugd29ya2Zsb3ciCnJlcG8gbW91bC9kZXB2aXoKCiMxICJTb2Z0IHNvdXJjZSIgW29wZW5dCiMyICJUYXJnZXQiIFtvcGVuXQojMSB-PiAjMiAibWF5YmUgYmxvY2tzIgo
2. Click the soft edge between `#1 Soft source` and `#2 Target`.
3. Expected: the edge turns red and both endpoint cards get a red outline.
4. Expected: the Selected edge inspector appears and shows `flow-soft`, `50%`, `soft`, and evidence `#1 ~> #2 "maybe blocks"`.
5. Click `Promote` in the inspector.
6. Expected: the Suggested relations panel disappears and the editor appends `#1 blocks #2`.
7. Expected: the inspector remains open, now describing the official promoted relation.

Local path:
1. Run `make live`.
2. Open `http://127.0.0.1:8686/?view=graph`.
3. Paste:

```depviz
board "Edge workflow"
repo moul/depviz

#1 "Soft source" [open]
#2 "Target" [open]
#1 ~> #2 "maybe blocks"
```

Then repeat the same click/promote checks above.

## Verification
- `make test`
- `node --check live/app/app.js`
- headless Chrome smoke: click edge opens inspector with endpoints/evidence, Clear hides it
- headless Chrome smoke: soft edge inspector shows Promote, promotion appends `#1 blocks #2` and clears suggestions
