### PR TITLE
feat: surface live github diagnostics

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.9-dev';
+const assetVersion = 'v4.1.10-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -38,6 +38,7 @@ const state = {
   showLocal: true,
   showClosed: true,
   githubRefresh: [],
+  githubFailures: [],
   selectedEdgeID: '',
   dismissedSuggestionIDs: new Set(),
   data: emptyExport(),
@@ -131,6 +132,7 @@ function readFile(event) {
 function update() {
   const text = dom.input.value;
   state.githubRefresh = [];
+  state.githubFailures = [];
   updateHighlight(text);
   dom.lineCount.textContent = `${countLines(text)} lines`;
   try {
@@ -254,12 +256,15 @@ async function hydrateGitHub() {
       try {
         updates.push(await fetchGitHubNode(ref, token));
       } catch (err) {
-        failures.push(`${ref.id}: ${err.message}`);
+        failures.push({ id: ref.id, message: err.message });
       }
     }
+    state.githubFailures = failures;
     if (updates.length > 0) {
       state.data = mergeHydratedNodes(state.data, updates);
       state.githubRefresh = githubRefreshItems(updates);
+    }
+    if (updates.length > 0 || failures.length > 0) {
       render();
     }
     const statusParts = [failures.length > 0
@@ -270,7 +275,7 @@ async function hydrateGitHub() {
     if (closedHidden > 0) statusParts.push(`${closedHidden} closed in refresh summary`);
     if (publicFallbacks > 0) statusParts.push(`${publicFallbacks} via public fallback`);
     dom.status.textContent = statusParts.join('; ');
-    dom.error.textContent = failures.slice(0, 2).join('  ');
+    dom.error.textContent = failures.slice(0, 2).map((item) => `${item.id}: ${item.message}`).join('  ');
   } finally {
     dom.hydrateGithub.disabled = false;
   }
@@ -1080,7 +1085,7 @@ function buildBrief(snapshot) {
       localOnly.push(briefItem(node, { reason: 'local-only planning card' }));
     }
     if (isPlaceholder(node) && !isLocal(node)) {
-      stale.push(briefItem(node, { reason: 'placeholder external ref; sync a wider scope' }));
+      stale.push(briefItem(node, { reason: 'placeholder external ref; refresh GitHub or sync/export a wider scope' }));
       continue;
     }
     const updated = Date.parse(node.updated_at || '');
@@ -1167,14 +1172,60 @@ function renderBrief(brief) {
   const githubRefresh = state.githubRefresh.length
     ? briefSection('GitHub refresh', state.githubRefresh, false)
     : '';
+  const githubDiagnostics = githubDiagnosticItems(state.data.snapshot);
   dom.brief.innerHTML = `<div class="briefGrid">
     ${githubRefresh}
+    ${githubDiagnostics.length ? briefSection('GitHub diagnostics', githubDiagnostics, false) : ''}
     ${briefSection('Next move', brief.next_move ? [brief.next_move] : [], true)}
     ${briefSection('Ready now', brief.ready || [], false)}
     ${briefSection('Blocking most work', brief.blockers || [], false)}
     ${briefSection('Local-only', brief.local_only || [], false)}
     ${briefSection('Stale external state', brief.stale || [], false)}
   </div>`;
+}
+
+function githubDiagnosticItems(snapshot) {
+  const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const items = [];
+  for (const failure of state.githubFailures) {
+    const node = nodes.get(failure.id) || placeholderNode(failure.id);
+    items.push(briefItem(node, { reason: `refresh failed: ${failure.message}` }));
+  }
+  for (const node of snapshot.nodes) {
+    if (isLocal(node)) continue;
+    const data = nodeData(node);
+    if (isUnhydratedExternalRef(node)) {
+      items.push(briefItem(node, { reason: 'unhydrated title/state; refresh GitHub or sync/export a wider scope' }));
+      continue;
+    }
+    if (Array.isArray(data.metadata_errors) && data.metadata_errors.length > 0) {
+      items.push(briefItem(node, { reason: `partial GitHub metadata: ${data.metadata_errors.slice(0, 2).join(', ')}` }));
+      continue;
+    }
+    if (data.auth_fallback) {
+      items.push(briefItem(node, { reason: 'token lacked scope; refreshed through public GitHub fallback' }));
+    }
+  }
+  dedupeBriefItems(items);
+  sortItems(items);
+  return items.slice(0, 12);
+}
+
+function isUnhydratedExternalRef(node) {
+  const data = nodeData(node);
+  if (data.hydrated) return false;
+  if (!parseGitHubNodeID(node.id)) return isPlaceholder(node);
+  return isPlaceholder(node) || node.title === node.id || String(node.state || '').toLowerCase() === 'unknown';
+}
+
+function dedupeBriefItems(items) {
+  const seen = new Set();
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index];
+    const key = `${item.id}\x00${item.reason}`;
+    if (seen.has(key)) items.splice(index, 1);
+    else seen.add(key);
+  }
 }
 
 function briefSection(title, items, wide) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.9-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.10-dev">
 </head>
 <body>
   <header class="topbar">
@@ -77,6 +77,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.9-dev"></script>
+  <script src="./app.js?v=v4.1.10-dev"></script>
 </body>
 </html>

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -99,3 +99,25 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 		}
 	}
 }
+
+func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
+	fsys := AppFS()
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"diagnostics section", string(app), `GitHub diagnostics`},
+		{"refresh failures", string(app), `state.githubFailures`},
+		{"placeholder guidance", string(app), `refresh GitHub or sync/export a wider scope`},
+		{"partial metadata", string(app), `partial GitHub metadata`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GitHub diagnostics section to the Live brief
- surface unhydrated refs, placeholders, partial metadata, public fallbacks, and refresh failures
- keep diagnostics visible even when every GitHub refresh attempt fails
- add static asset coverage for the diagnostics hooks

## Manual QA
Tailnet deployment path:
1. Open https://russel.donkey-shark.ts.net:8452/ while on the tailnet.
2. Paste:

```depviz
repo moul/depviz
#1 depends on #2
```

3. Expected: Brief shows a `GitHub diagnostics` section with unhydrated title/state guidance.
4. Click `Refresh GitHub` with no token or a bad/private ref.
5. Expected: failed refs stay visible as refresh diagnostics.

Local path:
1. Run `make live`.
2. Open http://127.0.0.1:8686/ and repeat the same paste/refresh checks.

## Verification
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
