### PR TITLE
feat: locate selected graph edges

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.10-dev';
+const assetVersion = 'v4.1.11-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -1531,6 +1531,7 @@ function renderEdgeInspector(snapshot) {
       </div>
       <div class="edgeActions">
         ${suggestionActions}
+        <button type="button" data-edge-action="locate">Locate in graph</button>
         <button type="button" data-edge-action="clear">Clear</button>
       </div>
     </div>
@@ -1564,6 +1565,11 @@ function handleEdgeInspectorClick(event) {
     render();
     dom.status.textContent = 'edge selection cleared';
   }
+  if (button.dataset.edgeAction === 'locate') {
+    setView('graph', { persist: true, renderNow: true });
+    requestAnimationFrame(scrollSelectedEdgeIntoView);
+    dom.status.textContent = 'selected edge located';
+  }
   if (button.dataset.edgeAction === 'promote') promoteSuggestedEdge(edgeID);
   if (button.dataset.edgeAction === 'hide') dismissSuggestedEdge(edgeID);
 }
@@ -1582,10 +1588,15 @@ function focusSuggestedEdge(edgeID) {
   if (!edgeByID(edgeID)) return;
   state.selectedEdgeID = edgeID;
   setView('graph', { persist: true, renderNow: true });
-  requestAnimationFrame(() => {
-    dom.graphCanvas.querySelector('.selectedEndpoint')?.scrollIntoView({ block: 'center', inline: 'center' });
-  });
+  requestAnimationFrame(scrollSelectedEdgeIntoView);
   dom.status.textContent = 'suggested relation focused';
+}
+
+function scrollSelectedEdgeIntoView() {
+  const endpoints = dom.graphCanvas.querySelectorAll('.selectedEndpoint');
+  if (endpoints.length === 0) return;
+  const target = endpoints[Math.floor((endpoints.length - 1) / 2)];
+  target.scrollIntoView({ block: 'center', inline: 'center' });
 }
 
 function dismissSuggestedEdge(edgeID) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.10-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.11-dev">
 </head>
 <body>
   <header class="topbar">
@@ -77,6 +77,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.10-dev"></script>
+  <script src="./app.js?v=v4.1.11-dev"></script>
 </body>
 </html>

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -91,6 +91,8 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 	}{
 		{"inspector mount", string(index), `id="edgeInspector"`},
 		{"edge hit target", string(app), `class="graphEdgeHit"`},
+		{"edge locate", string(app), `data-edge-action="locate"`},
+		{"edge locate scroll", string(app), `function scrollSelectedEdgeIntoView()`},
 		{"inspector promote", string(app), `data-edge-action="promote"`},
 		{"edge actions", string(style), `.edgeActions`},
 	} {


### PR DESCRIPTION
## Summary
- add a Locate in graph action to the Selected edge inspector
- reuse the same selected-endpoint centering behavior for suggested relation focus
- bump Live asset tags and extend static asset coverage

## Stack
This is stacked on #692 (`codex/live-github-diagnostics`).

## Manual QA
Fast path after the PR preview publishes:
1. Open the Live preview with `?view=brief` or use local `make live`.
2. Paste:

```depviz
board "Locate edge"
repo moul/depviz
#1 "Source" [open]
#2 "Target" [open]
#1 ~> #2 "maybe blocks"
```

3. Click `Focus` in Suggested relations.
4. Expected: Graph view opens, selected endpoints are centered, and the edge inspector is visible.
5. Switch away from Graph, then click `Locate in graph` in the edge inspector.
6. Expected: Graph view opens and centers the selected edge endpoints again.

## Verification
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
