### PR TITLE
feat: add live graph zoom controls

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.11-dev';
+const assetVersion = 'v4.1.12-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -16,6 +16,7 @@ const dom = {
   stats: document.getElementById('stats'),
   suggestions: document.getElementById('suggestionPanel'),
   edgeInspector: document.getElementById('edgeInspector'),
+  graphZoomLabel: document.getElementById('graphZoomLabel'),
   brief: document.getElementById('briefView'),
   graph: document.getElementById('graphView'),
   graphCanvas: document.getElementById('graphCanvas'),
@@ -40,6 +41,8 @@ const state = {
   githubRefresh: [],
   githubFailures: [],
   selectedEdgeID: '',
+  graphZoom: 1,
+  graphLayout: { width: 900, height: 620 },
   dismissedSuggestionIDs: new Set(),
   data: emptyExport(),
 };
@@ -110,6 +113,7 @@ function wireEvents() {
   dom.suggestions.addEventListener('click', handleSuggestionClick);
   dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
+  document.getElementById('graphView').addEventListener('click', handleGraphControlClick);
 }
 
 async function loadSample() {
@@ -1249,8 +1253,11 @@ function renderGraph(snapshot, nodes) {
   const selectedEdge = edgeByID(state.selectedEdgeID);
   const selectedEndpoints = selectedEdge ? new Set([selectedEdge.from_id, selectedEdge.to_id]) : new Set();
   const layout = graphLayout(snapshot, nodes);
+  state.graphLayout = { width: layout.width, height: layout.height };
+  const zoom = graphZoom();
   const positions = layout.positions;
-  let html = `<div class="graphInner" style="width:${layout.width}px;min-height:${layout.height}px">
+  let html = `<div class="graphScale" style="width:${Math.ceil(layout.width * zoom)}px;min-height:${Math.ceil(layout.height * zoom)}px">
+  <div class="graphInner" style="width:${layout.width}px;min-height:${layout.height}px;transform:scale(${zoom})">
     <svg class="edgeLayer" width="${layout.width}" height="${layout.height}" aria-hidden="true">
       <defs>
         <marker id="arrowHard" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L7,3 z" fill="#667085"></path></marker>
@@ -1282,8 +1289,39 @@ function renderGraph(snapshot, nodes) {
       ${badgesHTML(nodeBadges(node))}
     </article>`;
   }
-  html += '</div>';
+  html += '</div></div>';
   dom.graphCanvas.innerHTML = html;
+  dom.graphZoomLabel.textContent = `${Math.round(zoom * 100)}%`;
+}
+
+function handleGraphControlClick(event) {
+  const button = event.target.closest('[data-graph-action]');
+  if (!button) return;
+  const action = button.dataset.graphAction;
+  if (action === 'fit') {
+    fitGraphToCanvas();
+    return;
+  }
+  if (action === 'reset') state.graphZoom = 1;
+  if (action === 'in') state.graphZoom = graphZoom(state.graphZoom + 0.15);
+  if (action === 'out') state.graphZoom = graphZoom(state.graphZoom - 0.15);
+  render();
+}
+
+function fitGraphToCanvas() {
+  const width = Math.max(1, state.graphLayout.width);
+  const height = Math.max(1, state.graphLayout.height);
+  const next = Math.min(
+    (dom.graphCanvas.clientWidth - 28) / width,
+    (dom.graphCanvas.clientHeight - 28) / height,
+  );
+  state.graphZoom = graphZoom(next);
+  render();
+  dom.graphCanvas.scrollTo({ top: 0, left: 0 });
+}
+
+function graphZoom(value = state.graphZoom) {
+  return Math.max(0.35, Math.min(1.8, Number(value) || 1));
 }
 
 function handleGraphClick(event) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.11-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.12-dev">
 </head>
 <body>
   <header class="topbar">
@@ -71,12 +71,19 @@
       <div id="edgeInspector" class="edgeInspector hidden"></div>
       <div id="briefView" class="view"></div>
       <div id="graphView" class="view hidden">
+        <div class="graphToolbar" aria-label="Graph controls">
+          <button type="button" data-graph-action="fit">Fit</button>
+          <button type="button" data-graph-action="out">-</button>
+          <span id="graphZoomLabel">100%</span>
+          <button type="button" data-graph-action="in">+</button>
+          <button type="button" data-graph-action="reset">100%</button>
+        </div>
         <div id="graphCanvas" class="graphCanvas"></div>
       </div>
       <div id="tableView" class="view hidden"></div>
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.11-dev"></script>
+  <script src="./app.js?v=v4.1.12-dev"></script>
 </body>
 </html>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -749,10 +749,30 @@ textarea::selection {
   background: var(--panel);
 }
 
+.graphToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.graphToolbar span {
+  min-width: 44px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.graphScale {
+  position: relative;
+}
+
 .graphInner {
   position: relative;
   min-width: 900px;
   min-height: 620px;
+  transform-origin: 0 0;
 }
 
 .edgeLayer {

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -102,6 +102,37 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 	}
 }
 
+func TestLiveAssetsExposeGraphZoomControls(t *testing.T) {
+	fsys := AppFS()
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	style, err := fs.ReadFile(fsys, "style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"toolbar", string(index), `class="graphToolbar"`},
+		{"fit action", string(index), `data-graph-action="fit"`},
+		{"zoom helper", string(app), `function graphZoom(`},
+		{"fit helper", string(app), `function fitGraphToCanvas()`},
+		{"scale wrapper", string(style), `.graphScale`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}
+
 func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
 	fsys := AppFS()
 	app, err := fs.ReadFile(fsys, "app.js")


### PR DESCRIPTION
## Summary
- add Fit, zoom out, zoom in, and reset controls to the Live graph view
- scale the graph through a wrapper that preserves scroll dimensions
- show the current zoom percentage and cover the controls in static asset tests

## Stack
This is stacked on #693 (`codex/live-edge-locate`).

## Manual QA
Fast path after the PR preview publishes:
1. Open the Live preview with `?view=graph`, or run `make live` and open `http://127.0.0.1:8686/?view=graph`.
2. Load the sample or paste a graph with several connected nodes.
3. Click `Fit`.
4. Expected: the graph scales down to fit the canvas and the zoom label updates.
5. Click `+`, `-`, and `100%`.
6. Expected: graph scales smoothly, remains scrollable, and selected edge highlighting still aligns with cards.

## Verification
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
