### PR TITLE
feat: improve live graph ergonomics

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.12-dev';
+const assetVersion = 'v4.1.13-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -114,6 +114,7 @@ function wireEvents() {
   dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
   document.getElementById('graphView').addEventListener('click', handleGraphControlClick);
+  document.addEventListener('keydown', handleGraphKeydown);
 }
 
 async function loadSample() {
@@ -1297,7 +1298,42 @@ function renderGraph(snapshot, nodes) {
 function handleGraphControlClick(event) {
   const button = event.target.closest('[data-graph-action]');
   if (!button) return;
-  const action = button.dataset.graphAction;
+  applyGraphAction(button.dataset.graphAction);
+}
+
+function handleGraphKeydown(event) {
+  if (state.view !== 'graph' || isTypingTarget(event.target)) return;
+  const key = event.key.toLowerCase();
+  if (key === 'f') {
+    event.preventDefault();
+    applyGraphAction('fit');
+  }
+  if (key === '+' || key === '=') {
+    event.preventDefault();
+    applyGraphAction('in');
+  }
+  if (key === '-' || key === '_') {
+    event.preventDefault();
+    applyGraphAction('out');
+  }
+  if (key === '0') {
+    event.preventDefault();
+    applyGraphAction('reset');
+  }
+  if (key === 'escape' && state.selectedEdgeID) {
+    event.preventDefault();
+    state.selectedEdgeID = '';
+    render();
+    dom.status.textContent = 'edge selection cleared';
+  }
+}
+
+function isTypingTarget(target) {
+  const tag = String(target?.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(target?.isContentEditable);
+}
+
+function applyGraphAction(action) {
   if (action === 'fit') {
     fitGraphToCanvas();
     return;

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.10-dev';
+const assetVersion = 'v4.1.11-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -1531,6 +1531,7 @@ function renderEdgeInspector(snapshot) {
       </div>
       <div class="edgeActions">
         ${suggestionActions}
+        <button type="button" data-edge-action="locate">Locate in graph</button>
         <button type="button" data-edge-action="clear">Clear</button>
       </div>
     </div>
@@ -1564,6 +1565,11 @@ function handleEdgeInspectorClick(event) {
     render();
     dom.status.textContent = 'edge selection cleared';
   }
+  if (button.dataset.edgeAction === 'locate') {
+    setView('graph', { persist: true, renderNow: true });
+    requestAnimationFrame(scrollSelectedEdgeIntoView);
+    dom.status.textContent = 'selected edge located';
+  }
   if (button.dataset.edgeAction === 'promote') promoteSuggestedEdge(edgeID);
   if (button.dataset.edgeAction === 'hide') dismissSuggestedEdge(edgeID);
 }
@@ -1582,10 +1588,15 @@ function focusSuggestedEdge(edgeID) {
   if (!edgeByID(edgeID)) return;
   state.selectedEdgeID = edgeID;
   setView('graph', { persist: true, renderNow: true });
-  requestAnimationFrame(() => {
-    dom.graphCanvas.querySelector('.selectedEndpoint')?.scrollIntoView({ block: 'center', inline: 'center' });
-  });
+  requestAnimationFrame(scrollSelectedEdgeIntoView);
   dom.status.textContent = 'suggested relation focused';
+}
+
+function scrollSelectedEdgeIntoView() {
+  const endpoints = dom.graphCanvas.querySelectorAll('.selectedEndpoint');
+  if (endpoints.length === 0) return;
+  const target = endpoints[Math.floor((endpoints.length - 1) / 2)];
+  target.scrollIntoView({ block: 'center', inline: 'center' });
 }
 
 function dismissSuggestedEdge(edgeID) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.9-dev';
+const assetVersion = 'v4.1.10-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -38,6 +38,7 @@ const state = {
   showLocal: true,
   showClosed: true,
   githubRefresh: [],
+  githubFailures: [],
   selectedEdgeID: '',
   dismissedSuggestionIDs: new Set(),
   data: emptyExport(),
@@ -131,6 +132,7 @@ function readFile(event) {
 function update() {
   const text = dom.input.value;
   state.githubRefresh = [];
+  state.githubFailures = [];
   updateHighlight(text);
   dom.lineCount.textContent = `${countLines(text)} lines`;
   try {
@@ -254,12 +256,15 @@ async function hydrateGitHub() {
       try {
         updates.push(await fetchGitHubNode(ref, token));
       } catch (err) {
-        failures.push(`${ref.id}: ${err.message}`);
+        failures.push({ id: ref.id, message: err.message });
       }
     }
+    state.githubFailures = failures;
     if (updates.length > 0) {
       state.data = mergeHydratedNodes(state.data, updates);
       state.githubRefresh = githubRefreshItems(updates);
+    }
+    if (updates.length > 0 || failures.length > 0) {
       render();
     }
     const statusParts = [failures.length > 0
@@ -270,7 +275,7 @@ async function hydrateGitHub() {
     if (closedHidden > 0) statusParts.push(`${closedHidden} closed in refresh summary`);
     if (publicFallbacks > 0) statusParts.push(`${publicFallbacks} via public fallback`);
     dom.status.textContent = statusParts.join('; ');
-    dom.error.textContent = failures.slice(0, 2).join('  ');
+    dom.error.textContent = failures.slice(0, 2).map((item) => `${item.id}: ${item.message}`).join('  ');
   } finally {
     dom.hydrateGithub.disabled = false;
   }
@@ -1080,7 +1085,7 @@ function buildBrief(snapshot) {
       localOnly.push(briefItem(node, { reason: 'local-only planning card' }));
     }
     if (isPlaceholder(node) && !isLocal(node)) {
-      stale.push(briefItem(node, { reason: 'placeholder external ref; sync a wider scope' }));
+      stale.push(briefItem(node, { reason: 'placeholder external ref; refresh GitHub or sync/export a wider scope' }));
       continue;
     }
     const updated = Date.parse(node.updated_at || '');
@@ -1167,14 +1172,60 @@ function renderBrief(brief) {
   const githubRefresh = state.githubRefresh.length
     ? briefSection('GitHub refresh', state.githubRefresh, false)
     : '';
+  const githubDiagnostics = githubDiagnosticItems(state.data.snapshot);
   dom.brief.innerHTML = `<div class="briefGrid">
     ${githubRefresh}
+    ${githubDiagnostics.length ? briefSection('GitHub diagnostics', githubDiagnostics, false) : ''}
     ${briefSection('Next move', brief.next_move ? [brief.next_move] : [], true)}
     ${briefSection('Ready now', brief.ready || [], false)}
     ${briefSection('Blocking most work', brief.blockers || [], false)}
     ${briefSection('Local-only', brief.local_only || [], false)}
     ${briefSection('Stale external state', brief.stale || [], false)}
   </div>`;
+}
+
+function githubDiagnosticItems(snapshot) {
+  const nodes = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const items = [];
+  for (const failure of state.githubFailures) {
+    const node = nodes.get(failure.id) || placeholderNode(failure.id);
+    items.push(briefItem(node, { reason: `refresh failed: ${failure.message}` }));
+  }
+  for (const node of snapshot.nodes) {
+    if (isLocal(node)) continue;
+    const data = nodeData(node);
+    if (isUnhydratedExternalRef(node)) {
+      items.push(briefItem(node, { reason: 'unhydrated title/state; refresh GitHub or sync/export a wider scope' }));
+      continue;
+    }
+    if (Array.isArray(data.metadata_errors) && data.metadata_errors.length > 0) {
+      items.push(briefItem(node, { reason: `partial GitHub metadata: ${data.metadata_errors.slice(0, 2).join(', ')}` }));
+      continue;
+    }
+    if (data.auth_fallback) {
+      items.push(briefItem(node, { reason: 'token lacked scope; refreshed through public GitHub fallback' }));
+    }
+  }
+  dedupeBriefItems(items);
+  sortItems(items);
+  return items.slice(0, 12);
+}
+
+function isUnhydratedExternalRef(node) {
+  const data = nodeData(node);
+  if (data.hydrated) return false;
+  if (!parseGitHubNodeID(node.id)) return isPlaceholder(node);
+  return isPlaceholder(node) || node.title === node.id || String(node.state || '').toLowerCase() === 'unknown';
+}
+
+function dedupeBriefItems(items) {
+  const seen = new Set();
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index];
+    const key = `${item.id}\x00${item.reason}`;
+    if (seen.has(key)) items.splice(index, 1);
+    else seen.add(key);
+  }
 }
 
 function briefSection(title, items, wide) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.11-dev';
+const assetVersion = 'v4.1.12-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -16,6 +16,7 @@ const dom = {
   stats: document.getElementById('stats'),
   suggestions: document.getElementById('suggestionPanel'),
   edgeInspector: document.getElementById('edgeInspector'),
+  graphZoomLabel: document.getElementById('graphZoomLabel'),
   brief: document.getElementById('briefView'),
   graph: document.getElementById('graphView'),
   graphCanvas: document.getElementById('graphCanvas'),
@@ -40,6 +41,8 @@ const state = {
   githubRefresh: [],
   githubFailures: [],
   selectedEdgeID: '',
+  graphZoom: 1,
+  graphLayout: { width: 900, height: 620 },
   dismissedSuggestionIDs: new Set(),
   data: emptyExport(),
 };
@@ -110,6 +113,7 @@ function wireEvents() {
   dom.suggestions.addEventListener('click', handleSuggestionClick);
   dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
+  document.getElementById('graphView').addEventListener('click', handleGraphControlClick);
 }
 
 async function loadSample() {
@@ -1249,8 +1253,11 @@ function renderGraph(snapshot, nodes) {
   const selectedEdge = edgeByID(state.selectedEdgeID);
   const selectedEndpoints = selectedEdge ? new Set([selectedEdge.from_id, selectedEdge.to_id]) : new Set();
   const layout = graphLayout(snapshot, nodes);
+  state.graphLayout = { width: layout.width, height: layout.height };
+  const zoom = graphZoom();
   const positions = layout.positions;
-  let html = `<div class="graphInner" style="width:${layout.width}px;min-height:${layout.height}px">
+  let html = `<div class="graphScale" style="width:${Math.ceil(layout.width * zoom)}px;min-height:${Math.ceil(layout.height * zoom)}px">
+  <div class="graphInner" style="width:${layout.width}px;min-height:${layout.height}px;transform:scale(${zoom})">
     <svg class="edgeLayer" width="${layout.width}" height="${layout.height}" aria-hidden="true">
       <defs>
         <marker id="arrowHard" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L7,3 z" fill="#667085"></path></marker>
@@ -1282,8 +1289,39 @@ function renderGraph(snapshot, nodes) {
       ${badgesHTML(nodeBadges(node))}
     </article>`;
   }
-  html += '</div>';
+  html += '</div></div>';
   dom.graphCanvas.innerHTML = html;
+  dom.graphZoomLabel.textContent = `${Math.round(zoom * 100)}%`;
+}
+
+function handleGraphControlClick(event) {
+  const button = event.target.closest('[data-graph-action]');
+  if (!button) return;
+  const action = button.dataset.graphAction;
+  if (action === 'fit') {
+    fitGraphToCanvas();
+    return;
+  }
+  if (action === 'reset') state.graphZoom = 1;
+  if (action === 'in') state.graphZoom = graphZoom(state.graphZoom + 0.15);
+  if (action === 'out') state.graphZoom = graphZoom(state.graphZoom - 0.15);
+  render();
+}
+
+function fitGraphToCanvas() {
+  const width = Math.max(1, state.graphLayout.width);
+  const height = Math.max(1, state.graphLayout.height);
+  const next = Math.min(
+    (dom.graphCanvas.clientWidth - 28) / width,
+    (dom.graphCanvas.clientHeight - 28) / height,
+  );
+  state.graphZoom = graphZoom(next);
+  render();
+  dom.graphCanvas.scrollTo({ top: 0, left: 0 });
+}
+
+function graphZoom(value = state.graphZoom) {
+  return Math.max(0.35, Math.min(1.8, Number(value) || 1));
 }
 
 function handleGraphClick(event) {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.10-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.11-dev">
 </head>
 <body>
   <header class="topbar">
@@ -77,6 +77,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.10-dev"></script>
+  <script src="./app.js?v=v4.1.11-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.12-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.13-dev">
 </head>
 <body>
   <header class="topbar">
@@ -84,6 +84,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.12-dev"></script>
+  <script src="./app.js?v=v4.1.13-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.9-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.10-dev">
 </head>
 <body>
   <header class="topbar">
@@ -77,6 +77,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.9-dev"></script>
+  <script src="./app.js?v=v4.1.10-dev"></script>
 </body>
 </html>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.11-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.12-dev">
 </head>
 <body>
   <header class="topbar">
@@ -71,12 +71,19 @@
       <div id="edgeInspector" class="edgeInspector hidden"></div>
       <div id="briefView" class="view"></div>
       <div id="graphView" class="view hidden">
+        <div class="graphToolbar" aria-label="Graph controls">
+          <button type="button" data-graph-action="fit">Fit</button>
+          <button type="button" data-graph-action="out">-</button>
+          <span id="graphZoomLabel">100%</span>
+          <button type="button" data-graph-action="in">+</button>
+          <button type="button" data-graph-action="reset">100%</button>
+        </div>
         <div id="graphCanvas" class="graphCanvas"></div>
       </div>
       <div id="tableView" class="view hidden"></div>
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.11-dev"></script>
+  <script src="./app.js?v=v4.1.12-dev"></script>
 </body>
 </html>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -749,10 +749,30 @@ textarea::selection {
   background: var(--panel);
 }
 
+.graphToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.graphToolbar span {
+  min-width: 44px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.graphScale {
+  position: relative;
+}
+
 .graphInner {
   position: relative;
   min-width: 900px;
   min-height: 620px;
+  transform-origin: 0 0;
 }
 
 .edgeLayer {

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -102,6 +102,37 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 	}
 }
 
+func TestLiveAssetsExposeGraphZoomControls(t *testing.T) {
+	fsys := AppFS()
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	style, err := fs.ReadFile(fsys, "style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"toolbar", string(index), `class="graphToolbar"`},
+		{"fit action", string(index), `data-graph-action="fit"`},
+		{"zoom helper", string(app), `function graphZoom(`},
+		{"fit helper", string(app), `function fitGraphToCanvas()`},
+		{"scale wrapper", string(style), `.graphScale`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}
+
 func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
 	fsys := AppFS()
 	app, err := fs.ReadFile(fsys, "app.js")

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -91,6 +91,8 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 	}{
 		{"inspector mount", string(index), `id="edgeInspector"`},
 		{"edge hit target", string(app), `class="graphEdgeHit"`},
+		{"edge locate", string(app), `data-edge-action="locate"`},
+		{"edge locate scroll", string(app), `function scrollSelectedEdgeIntoView()`},
 		{"inspector promote", string(app), `data-edge-action="promote"`},
 		{"edge actions", string(style), `.edgeActions`},
 	} {

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -99,3 +99,25 @@ func TestLiveAssetsExposeEdgeInspectorWorkflow(t *testing.T) {
 		}
 	}
 }
+
+func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
+	fsys := AppFS()
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"diagnostics section", string(app), `GitHub diagnostics`},
+		{"refresh failures", string(app), `state.githubFailures`},
+		{"placeholder guidance", string(app), `refresh GitHub or sync/export a wider scope`},
+		{"partial metadata", string(app), `partial GitHub metadata`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -125,6 +125,8 @@ func TestLiveAssetsExposeGraphZoomControls(t *testing.T) {
 		{"fit action", string(index), `data-graph-action="fit"`},
 		{"zoom helper", string(app), `function graphZoom(`},
 		{"fit helper", string(app), `function fitGraphToCanvas()`},
+		{"keyboard helper", string(app), `function handleGraphKeydown(event)`},
+		{"typing guard", string(app), `function isTypingTarget(target)`},
 		{"scale wrapper", string(style), `.graphScale`},
 	} {
 		if !strings.Contains(tc.body, tc.want) {


### PR DESCRIPTION
## Summary
- full validation PR for the current Live graph ergonomics stack
- includes GitHub diagnostics from #692
- includes selected-edge locate behavior from #693
- includes graph zoom controls from #694
- includes graph keyboard controls from #696

## Stack
This PR is the combined-review/validation PR against `master`.

Step PRs:
- #692: GitHub diagnostics
- #693: selected edge locate action
- #694: graph zoom controls
- #696: graph keyboard controls

I will update this branch as more small slices are added.

## Manual QA
1. Open the PR preview after Pages publishes, or run `make live` locally.
2. Use this input:

```depviz
board "Graph ergonomics"
repo moul/depviz

#1 "Source" [open]
#2 "Target" [open]
#3 "Blocked" [open]
#1 ~> #2 "maybe blocks"
#2 blocks #3
```

3. Expected: Brief shows GitHub diagnostics for unhydrated refs.
4. Click `Focus` on the suggested relation.
5. Expected: Graph opens, selected endpoints are centered, and the inspector shows the selected edge.
6. Use `Fit`, `+`, `-`, and `100%` in Graph.
7. Expected: zoom changes the graph without losing selected edge alignment.
8. Press `f`, `+`, `-`, `0`, and `Escape` while Graph is active.
9. Expected: keyboard controls match toolbar behavior and Escape clears edge selection.

## Verification
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
