### PR TITLE
feat: add live graph keyboard controls

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.12-dev';
+const assetVersion = 'v4.1.13-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -114,6 +114,7 @@ function wireEvents() {
   dom.edgeInspector.addEventListener('click', handleEdgeInspectorClick);
   dom.graphCanvas.addEventListener('click', handleGraphClick);
   document.getElementById('graphView').addEventListener('click', handleGraphControlClick);
+  document.addEventListener('keydown', handleGraphKeydown);
 }
 
 async function loadSample() {
@@ -1297,7 +1298,42 @@ function renderGraph(snapshot, nodes) {
 function handleGraphControlClick(event) {
   const button = event.target.closest('[data-graph-action]');
   if (!button) return;
-  const action = button.dataset.graphAction;
+  applyGraphAction(button.dataset.graphAction);
+}
+
+function handleGraphKeydown(event) {
+  if (state.view !== 'graph' || isTypingTarget(event.target)) return;
+  const key = event.key.toLowerCase();
+  if (key === 'f') {
+    event.preventDefault();
+    applyGraphAction('fit');
+  }
+  if (key === '+' || key === '=') {
+    event.preventDefault();
+    applyGraphAction('in');
+  }
+  if (key === '-' || key === '_') {
+    event.preventDefault();
+    applyGraphAction('out');
+  }
+  if (key === '0') {
+    event.preventDefault();
+    applyGraphAction('reset');
+  }
+  if (key === 'escape' && state.selectedEdgeID) {
+    event.preventDefault();
+    state.selectedEdgeID = '';
+    render();
+    dom.status.textContent = 'edge selection cleared';
+  }
+}
+
+function isTypingTarget(target) {
+  const tag = String(target?.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(target?.isContentEditable);
+}
+
+function applyGraphAction(action) {
   if (action === 'fit') {
     fitGraphToCanvas();
     return;

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.12-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.13-dev">
 </head>
 <body>
   <header class="topbar">
@@ -84,6 +84,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.12-dev"></script>
+  <script src="./app.js?v=v4.1.13-dev"></script>
 </body>
 </html>

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -125,6 +125,8 @@ func TestLiveAssetsExposeGraphZoomControls(t *testing.T) {
 		{"fit action", string(index), `data-graph-action="fit"`},
 		{"zoom helper", string(app), `function graphZoom(`},
 		{"fit helper", string(app), `function fitGraphToCanvas()`},
+		{"keyboard helper", string(app), `function handleGraphKeydown(event)`},
+		{"typing guard", string(app), `function isTypingTarget(target)`},
 		{"scale wrapper", string(style), `.graphScale`},
 	} {
 		if !strings.Contains(tc.body, tc.want) {


### PR DESCRIPTION
## Summary
- add graph-view keyboard controls for fit, zoom in/out, reset, and clearing edge selection
- ignore graph shortcuts while typing in inputs or the source editor
- route toolbar clicks and keyboard shortcuts through the same graph action helper

## Stack
This is stacked on #694 (`codex/live-graph-zoom`).

## Manual QA
1. Open Live in Graph view through the PR preview or local `make live`.
2. Click the graph canvas or otherwise leave the editor/input focus.
3. Press `f`, `+`, `-`, and `0`.
4. Expected: the graph fits, zooms in, zooms out, and resets to 100%.
5. Select an edge, then press `Escape`.
6. Expected: the selected edge clears.
7. Focus the source editor and press the same keys.
8. Expected: text input is not hijacked by graph shortcuts.

## Verification
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
