### PR TITLE
feat: add backend auth foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ depviz brief
 depviz gen html --board default --view graph --out dist/depviz.html
 depviz gen json --board default --out dist/depviz.json
 depviz live --addr 127.0.0.1:8686
+depviz server --addr 127.0.0.1:8766 --base-url https://depviz.moul.io
 ```
 
 ## Live Mode
@@ -165,6 +166,33 @@ scan-friendly without changing the ready/blocker semantics.
 
 The static files live under `live/app/` and are deployable as-is through
 GitHub Pages. No Node.js build is required.
+
+## Backend Mode
+
+`depviz server` serves the same Live app plus `/api/*` endpoints backed by the
+local SQLite database. It is meant to sit behind a private reverse proxy or
+Cloudflare Tunnel while binding only to loopback:
+
+```text
+DEPVIZ_BASE_URL=https://depviz.moul.io \
+DEPVIZ_GITHUB_CLIENT_ID=... \
+DEPVIZ_GITHUB_CLIENT_SECRET=... \
+depviz server --addr 127.0.0.1:8766
+```
+
+Initial endpoints:
+
+```text
+GET /api/health
+GET /api/session
+GET /api/auth/github/start
+GET /api/auth/github/callback
+```
+
+When GitHub OAuth is configured, the daemon can create a local account, store
+the GitHub connection in `.depviz/state.db`, and issue an HTTP-only session
+cookie. The next backend slices can use that account connection for cached
+GitHub hydration and eventually write actions.
 
 The Pages workflow publishes:
 

--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"moul.io/depviz/v4/internal/backend"
 	"moul.io/depviz/v4/internal/core"
 	"moul.io/depviz/v4/live"
 )
@@ -60,6 +62,8 @@ func run(ctx context.Context, args []string) error {
 		return runSync(ctx, dbPath, args)
 	case "live":
 		return runLive(ctx, args)
+	case "server":
+		return runServer(ctx, dbPath, args)
 	default:
 		return fmt.Errorf("unknown command %q", cmd)
 	}
@@ -316,6 +320,38 @@ func runLive(ctx context.Context, args []string) error {
 	return http.ListenAndServe(*addr, http.FileServer(http.FS(live.AppFS())))
 }
 
+func runServer(ctx context.Context, dbPath string, args []string) error {
+	fs := flag.NewFlagSet("server", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	addr := fs.String("addr", envDefault("DEPVIZ_ADDR", "127.0.0.1:8766"), "listen address")
+	baseURL := fs.String("base-url", os.Getenv("DEPVIZ_BASE_URL"), "public base URL")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := core.OpenStore(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	cfg := backend.Config{
+		Addr:               *addr,
+		BaseURL:            *baseURL,
+		GitHubClientID:     os.Getenv("DEPVIZ_GITHUB_CLIENT_ID"),
+		GitHubClientSecret: os.Getenv("DEPVIZ_GITHUB_CLIENT_SECRET"),
+		SessionTTL:         30 * 24 * time.Hour,
+	}
+	srv := backend.NewServer(s, cfg)
+	fmt.Printf("serving DepViz backend at http://%s\n", *addr)
+	return http.ListenAndServe(*addr, srv.Handler())
+}
+
+func envDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
 func usage() {
 	fmt.Println(`depviz - local-first work graph
 
@@ -331,7 +367,12 @@ Usage:
   depviz gen html --board default --view graph --out dist/depviz.html
   depviz gen json --board default --out dist/depviz.json
   depviz live --addr 127.0.0.1:8686
+  depviz server --addr 127.0.0.1:8766 --base-url https://depviz.moul.io
 
 Environment:
-  DEPVIZ_DB   override .depviz/state.db`)
+  DEPVIZ_DB                    override .depviz/state.db
+  DEPVIZ_ADDR                  default server listen address
+  DEPVIZ_BASE_URL              public server URL for OAuth callbacks
+  DEPVIZ_GITHUB_CLIENT_ID      GitHub OAuth app client id
+  DEPVIZ_GITHUB_CLIENT_SECRET  GitHub OAuth app client secret`)
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1,0 +1,283 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"moul.io/depviz/v4/internal/core"
+	"moul.io/depviz/v4/live"
+)
+
+const sessionCookieName = "depviz_session"
+
+type Config struct {
+	Addr               string
+	BaseURL            string
+	GitHubClientID     string
+	GitHubClientSecret string
+	SessionTTL         time.Duration
+}
+
+type Server struct {
+	cfg    Config
+	store  *core.Store
+	client *http.Client
+}
+
+func NewServer(store *core.Store, cfg Config) *Server {
+	if cfg.SessionTTL <= 0 {
+		cfg.SessionTTL = 30 * 24 * time.Hour
+	}
+	return &Server{
+		cfg:    cfg,
+		store:  store,
+		client: http.DefaultClient,
+	}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health", s.handleHealth)
+	mux.HandleFunc("/api/session", s.handleSession)
+	mux.HandleFunc("/api/auth/github/start", s.handleGitHubStart)
+	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubCallback)
+	mux.Handle("/", http.FileServer(http.FS(live.AppFS())))
+	return mux
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":                      true,
+		"github_oauth_configured": s.githubOAuthConfigured(),
+	})
+}
+
+func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
+	account, ok, err := s.accountForRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	out := map[string]any{
+		"authenticated":           ok,
+		"github_oauth_configured": s.githubOAuthConfigured(),
+	}
+	if ok {
+		out["account"] = account
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
+	if !s.githubOAuthConfigured() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "github oauth is not configured"})
+		return
+	}
+	returnTo := safeReturnPath(r.URL.Query().Get("return_to"))
+	state, err := s.store.CreateOAuthState(r.Context(), "github", returnTo, 10*time.Minute)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	params := url.Values{
+		"client_id":    {s.cfg.GitHubClientID},
+		"redirect_uri": {s.callbackURL()},
+		"scope":        {"repo read:user user:email"},
+		"state":        {state},
+	}
+	http.Redirect(w, r, "https://github.com/login/oauth/authorize?"+params.Encode(), http.StatusFound)
+}
+
+func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
+	if !s.githubOAuthConfigured() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "github oauth is not configured"})
+		return
+	}
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	if code == "" || state == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing code or state"})
+		return
+	}
+	returnTo, err := s.store.ConsumeOAuthState(r.Context(), "github", state)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	token, err := s.exchangeGitHubCode(r.Context(), code)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	user, err := s.fetchGitHubUser(r.Context(), token.AccessToken)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	tokenJSON, _ := json.Marshal(token)
+	account, err := s.store.UpsertOAuthAccount(r.Context(), core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: fmt.Sprint(user.ID),
+		Login:      user.Login,
+		Name:       user.Name,
+		AvatarURL:  user.AvatarURL,
+		HTMLURL:    user.HTMLURL,
+		Scopes:     token.Scopes(),
+		TokenJSON:  string(tokenJSON),
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	session, expires, err := s.store.CreateWebSession(r.Context(), account.ID, s.cfg.SessionTTL)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    session,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   strings.HasPrefix(s.cfg.BaseURL, "https://"),
+	})
+	http.Redirect(w, r, returnTo, http.StatusFound)
+}
+
+func (s *Server) accountForRequest(r *http.Request) (core.Account, bool, error) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return core.Account{}, false, nil
+	}
+	return s.store.AccountForWebSession(r.Context(), cookie.Value)
+}
+
+func (s *Server) exchangeGitHubCode(ctx context.Context, code string) (githubToken, error) {
+	body, _ := json.Marshal(map[string]string{
+		"client_id":     s.cfg.GitHubClientID,
+		"client_secret": s.cfg.GitHubClientSecret,
+		"code":          code,
+		"redirect_uri":  s.callbackURL(),
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://github.com/login/oauth/access_token", bytes.NewReader(body))
+	if err != nil {
+		return githubToken{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	var token githubToken
+	if err := s.doJSON(req, &token); err != nil {
+		return githubToken{}, err
+	}
+	if token.Error != "" {
+		return githubToken{}, errors.New(token.ErrorDescription)
+	}
+	if token.AccessToken == "" {
+		return githubToken{}, errors.New("github did not return an access token")
+	}
+	return token, nil
+}
+
+func (s *Server) fetchGitHubUser(ctx context.Context, accessToken string) (githubUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		return githubUser{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	var user githubUser
+	if err := s.doJSON(req, &user); err != nil {
+		return githubUser{}, err
+	}
+	if user.ID == 0 || user.Login == "" {
+		return githubUser{}, errors.New("github user response is missing id or login")
+	}
+	return user, nil
+}
+
+func (s *Server) doJSON(req *http.Request, out any) error {
+	res, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("%s: %s", res.Status, strings.TrimSpace(string(data)))
+	}
+	return json.Unmarshal(data, out)
+}
+
+func (s *Server) callbackURL() string {
+	base := strings.TrimRight(s.cfg.BaseURL, "/")
+	if base == "" {
+		base = "http://" + s.cfg.Addr
+	}
+	return base + "/api/auth/github/callback"
+}
+
+func (s *Server) githubOAuthConfigured() bool {
+	return s.cfg.GitHubClientID != "" && s.cfg.GitHubClientSecret != ""
+}
+
+type githubToken struct {
+	AccessToken      string `json:"access_token"`
+	TokenType        string `json:"token_type"`
+	Scope            string `json:"scope"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (g githubToken) Scopes() []string {
+	if g.Scope == "" {
+		return nil
+	}
+	parts := strings.Split(g.Scope, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+type githubUser struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	HTMLURL   string `json:"html_url"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func safeReturnPath(value string) string {
+	if value == "" {
+		return "/"
+	}
+	u, err := url.Parse(value)
+	if err != nil || u.IsAbs() || !strings.HasPrefix(value, "/") {
+		return "/"
+	}
+	return value
+}

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -1,0 +1,76 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"moul.io/depviz/v4/internal/core"
+)
+
+func TestHealthAndAnonymousSession(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/api/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	var health struct {
+		OK                    bool `json:"ok"`
+		GitHubOAuthConfigured bool `json:"github_oauth_configured"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&health); err != nil {
+		t.Fatal(err)
+	}
+	if !health.OK {
+		t.Fatal("health ok=false")
+	}
+	if health.GitHubOAuthConfigured {
+		t.Fatal("github oauth should not be configured")
+	}
+
+	res, err = http.Get(ts.URL + "/api/session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	var session struct {
+		Authenticated bool `json:"authenticated"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Authenticated {
+		t.Fatal("anonymous session is authenticated")
+	}
+}
+
+func TestGitHubStartRequiresConfig(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	srv := NewServer(store, Config{})
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/github/start", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -1,0 +1,197 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+type OAuthAccountInput struct {
+	Provider   string
+	ExternalID string
+	Login      string
+	Name       string
+	AvatarURL  string
+	HTMLURL    string
+	Scopes     []string
+	TokenJSON  string
+}
+
+func (s *Store) CreateOAuthState(ctx context.Context, provider, redirectURI string, ttl time.Duration) (string, error) {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return "", errors.New("oauth provider is required")
+	}
+	if redirectURI == "" {
+		redirectURI = "/"
+	}
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	state, err := randomToken(32)
+	if err != nil {
+		return "", err
+	}
+	now := nowUTC()
+	_, err = s.db.ExecContext(ctx, `INSERT INTO oauth_states(state, provider, redirect_uri, expires_at, created_at)
+		VALUES(?, ?, ?, ?, ?)`, state, provider, redirectURI, formatTime(now.Add(ttl)), formatTime(now))
+	return state, err
+}
+
+func (s *Store) ConsumeOAuthState(ctx context.Context, provider, state string) (string, error) {
+	var redirectURI, expires string
+	err := s.db.QueryRowContext(ctx, `SELECT redirect_uri, expires_at FROM oauth_states WHERE state = ? AND provider = ?`, state, provider).
+		Scan(&redirectURI, &expires)
+	if err != nil {
+		return "", errors.New("invalid oauth state")
+	}
+	_, _ = s.db.ExecContext(ctx, `DELETE FROM oauth_states WHERE state = ?`, state)
+	if exp := parseTime(expires); exp.IsZero() || exp.Before(nowUTC()) {
+		return "", errors.New("expired oauth state")
+	}
+	if redirectURI == "" {
+		redirectURI = "/"
+	}
+	return redirectURI, nil
+}
+
+func (s *Store) UpsertOAuthAccount(ctx context.Context, in OAuthAccountInput) (Account, error) {
+	in.Provider = strings.TrimSpace(in.Provider)
+	in.ExternalID = strings.TrimSpace(in.ExternalID)
+	in.Login = strings.TrimSpace(in.Login)
+	if in.Provider == "" || in.ExternalID == "" || in.Login == "" {
+		return Account{}, errors.New("provider, external id, and login are required")
+	}
+	now := nowUTC()
+	accountID := stableID("account", in.Provider, in.ExternalID)
+	var created string
+	err := s.db.QueryRowContext(ctx, `SELECT created_at FROM accounts WHERE id = ?`, accountID).Scan(&created)
+	if err != nil {
+		created = formatTime(now)
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO accounts(id, primary_provider, login, name, avatar_url, html_url, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			login=excluded.login,
+			name=excluded.name,
+			avatar_url=excluded.avatar_url,
+			html_url=excluded.html_url,
+			updated_at=excluded.updated_at`,
+		accountID, in.Provider, in.Login, in.Name, in.AvatarURL, in.HTMLURL, created, formatTime(now))
+	if err != nil {
+		return Account{}, err
+	}
+	scopesJSON, _ := json.Marshal(in.Scopes)
+	if in.TokenJSON == "" {
+		in.TokenJSON = `{}`
+	}
+	connectionID := stableID("oauth", in.Provider, in.ExternalID)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO oauth_connections(id, account_id, provider, external_id, login, scopes_json, token_json, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(provider, external_id) DO UPDATE SET
+			account_id=excluded.account_id,
+			login=excluded.login,
+			scopes_json=excluded.scopes_json,
+			token_json=excluded.token_json,
+			updated_at=excluded.updated_at`,
+		connectionID, accountID, in.Provider, in.ExternalID, in.Login, string(scopesJSON), in.TokenJSON, created, formatTime(now))
+	if err != nil {
+		return Account{}, err
+	}
+	return s.AccountByID(ctx, accountID)
+}
+
+func (s *Store) AccountByID(ctx context.Context, accountID string) (Account, error) {
+	var a Account
+	var created, updated string
+	err := s.db.QueryRowContext(ctx, `SELECT id, primary_provider, login, name, avatar_url, html_url, created_at, updated_at
+		FROM accounts WHERE id = ?`, accountID).
+		Scan(&a.ID, &a.PrimaryProvider, &a.Login, &a.Name, &a.AvatarURL, &a.HTMLURL, &created, &updated)
+	if err != nil {
+		return Account{}, err
+	}
+	a.CreatedAt = parseTime(created)
+	a.UpdatedAt = parseTime(updated)
+	return a, nil
+}
+
+func (s *Store) CreateWebSession(ctx context.Context, accountID string, ttl time.Duration) (string, time.Time, error) {
+	if accountID == "" {
+		return "", time.Time{}, errors.New("account id is required")
+	}
+	if ttl <= 0 {
+		ttl = 30 * 24 * time.Hour
+	}
+	token, err := randomToken(32)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	now := nowUTC()
+	expires := now.Add(ttl)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO web_sessions(token_hash, account_id, expires_at, created_at)
+		VALUES(?, ?, ?, ?)`, sessionHash(token), accountID, formatTime(expires), formatTime(now))
+	return token, expires, err
+}
+
+func (s *Store) AccountForWebSession(ctx context.Context, token string) (Account, bool, error) {
+	if token == "" {
+		return Account{}, false, nil
+	}
+	var accountID, expires string
+	err := s.db.QueryRowContext(ctx, `SELECT account_id, expires_at FROM web_sessions WHERE token_hash = ?`, sessionHash(token)).
+		Scan(&accountID, &expires)
+	if err != nil {
+		return Account{}, false, nil
+	}
+	if exp := parseTime(expires); exp.IsZero() || exp.Before(nowUTC()) {
+		_, _ = s.db.ExecContext(ctx, `DELETE FROM web_sessions WHERE token_hash = ?`, sessionHash(token))
+		return Account{}, false, nil
+	}
+	account, err := s.AccountByID(ctx, accountID)
+	if err != nil {
+		return Account{}, false, err
+	}
+	return account, true, nil
+}
+
+func (s *Store) UpsertGitHubCache(ctx context.Context, accountID, repo, refID, payloadJSON, etag string, ttl time.Duration) error {
+	if accountID == "" || repo == "" || refID == "" {
+		return errors.New("account id, repo, and ref id are required")
+	}
+	if payloadJSON == "" {
+		payloadJSON = `{}`
+	}
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	now := nowUTC()
+	id := stableID("github-cache", accountID, repo, refID)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO github_cache(id, account_id, repo, ref_id, payload_json, etag, fetched_at, expires_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, repo, ref_id) DO UPDATE SET
+			payload_json=excluded.payload_json,
+			etag=excluded.etag,
+			fetched_at=excluded.fetched_at,
+			expires_at=excluded.expires_at`,
+		id, accountID, repo, refID, payloadJSON, etag, formatTime(now), formatTime(now.Add(ttl)))
+	return err
+}
+
+func randomToken(bytes int) (string, error) {
+	buf := make([]byte, bytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func sessionHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOAuthAccountAndWebSession(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	state, err := s.CreateOAuthState(ctx, "github", "/graph", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirect, err := s.ConsumeOAuthState(ctx, "github", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if redirect != "/graph" {
+		t.Fatalf("redirect = %q, want /graph", redirect)
+	}
+	if _, err := s.ConsumeOAuthState(ctx, "github", state); err == nil {
+		t.Fatal("expected consumed oauth state to be invalid")
+	}
+
+	account, err := s.UpsertOAuthAccount(ctx, OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+		Name:       "Manfred",
+		Scopes:     []string{"repo", "read:user"},
+		TokenJSON:  `{"access_token":"redacted"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := s.CreateWebSession(ctx, account.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.AccountForWebSession(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("session did not authenticate")
+	}
+	if got.Login != "moul" {
+		t.Fatalf("login = %q, want moul", got.Login)
+	}
+}

--- a/internal/core/model.go
+++ b/internal/core/model.go
@@ -100,6 +100,17 @@ type BriefItem struct {
 	BlockerCount int    `json:"blocker_count,omitempty"`
 }
 
+type Account struct {
+	ID              string    `json:"id"`
+	PrimaryProvider string    `json:"primary_provider"`
+	Login           string    `json:"login"`
+	Name            string    `json:"name"`
+	AvatarURL       string    `json:"avatar_url"`
+	HTMLURL         string    `json:"html_url"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
 func (n Node) IsClosed() bool {
 	switch strings.ToLower(strings.TrimSpace(n.State)) {
 	case "closed", "done", "merged", "cancelled", "canceled", "resolved":

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -141,6 +141,52 @@ func (s *Store) Migrate(ctx context.Context) error {
 			source_id TEXT NOT NULL DEFAULT '',
 			updated_at TEXT NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+			id TEXT PRIMARY KEY,
+			primary_provider TEXT NOT NULL,
+			login TEXT NOT NULL,
+			name TEXT NOT NULL DEFAULT '',
+			avatar_url TEXT NOT NULL DEFAULT '',
+			html_url TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS oauth_connections (
+			id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			provider TEXT NOT NULL,
+			external_id TEXT NOT NULL,
+			login TEXT NOT NULL,
+			scopes_json TEXT NOT NULL DEFAULT '[]',
+			token_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			UNIQUE(provider, external_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS oauth_states (
+			state TEXT PRIMARY KEY,
+			provider TEXT NOT NULL,
+			redirect_uri TEXT NOT NULL DEFAULT '/',
+			expires_at TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS web_sessions (
+			token_hash TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			expires_at TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS github_cache (
+			id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			repo TEXT NOT NULL,
+			ref_id TEXT NOT NULL,
+			payload_json TEXT NOT NULL,
+			etag TEXT NOT NULL DEFAULT '',
+			fetched_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			UNIQUE(account_id, repo, ref_id)
+		)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.ExecContext(ctx, stmt); err != nil {


### PR DESCRIPTION
## Summary
- add `depviz server`, a loopback backend that serves Live plus `/api/*`
- add SQLite account, OAuth connection, OAuth state, web session, and GitHub cache tables
- add GitHub OAuth start/callback plumbing with HTTP-only sessions
- expose health/session APIs that work before OAuth credentials are configured
- document the `depviz.moul.io` backend deployment env vars

## Deployment Notes
For the current `depviz.moul.io` tunnel shape, the daemon should run on loopback:

```text
DEPVIZ_BASE_URL=https://depviz.moul.io
DEPVIZ_GITHUB_CLIENT_ID=...
DEPVIZ_GITHUB_CLIENT_SECRET=...
depviz server --addr 127.0.0.1:8766
```

GitHub OAuth app callback URL:

```text
https://depviz.moul.io/api/auth/github/callback
```

The current first-slice APIs are:

```text
GET /api/health
GET /api/session
GET /api/auth/github/start
GET /api/auth/github/callback
```

`/api/auth/github/start` returns 503 until the GitHub OAuth env vars are set.

## Manual QA
Local path:
1. Run:

```text
tmpdir=$(mktemp -d)
DEPVIZ_DB="$tmpdir/state.db" depviz server --addr 127.0.0.1:8766 --base-url http://127.0.0.1:8766
```

2. Open `http://127.0.0.1:8766/`.
3. Check `curl http://127.0.0.1:8766/api/health`.
4. Check `curl http://127.0.0.1:8766/api/session`.
5. Check `curl -i http://127.0.0.1:8766/api/auth/github/start` returns 503 without env vars.

OAuth path after credentials exist:
1. Configure a GitHub OAuth app callback URL: `https://depviz.moul.io/api/auth/github/callback`.
2. Set `DEPVIZ_GITHUB_CLIENT_ID` and `DEPVIZ_GITHUB_CLIENT_SECRET` on the daemon.
3. Open `https://depviz.moul.io/api/auth/github/start`.
4. Expected: GitHub auth completes and `/api/session` returns an authenticated account.

## Verification
- `/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin/gofmt -w ...`
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
- loopback smoke: Live HTML, `/api/health`, `/api/session`, and no-credential OAuth 503
