### PR TITLE
feat: connect live to backend sessions

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -49,6 +49,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/session", s.handleSession)
 	mux.HandleFunc("/api/auth/github/start", s.handleGitHubStart)
 	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubCallback)
+	mux.HandleFunc("/api/auth/logout", s.handleLogout)
 	mux.Handle("/", http.FileServer(http.FS(live.AppFS())))
 	return mux
 }
@@ -152,6 +153,28 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		Secure:   strings.HasPrefix(s.cfg.BaseURL, "https://"),
 	})
 	http.Redirect(w, r, returnTo, http.StatusFound)
+}
+
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	cookie, err := r.Cookie(sessionCookieName)
+	if err == nil {
+		_ = s.store.DeleteWebSession(r.Context(), cookie.Value)
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   strings.HasPrefix(s.cfg.BaseURL, "https://"),
+	})
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 func (s *Server) accountForRequest(r *http.Request) (core.Account, bool, error) {

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -74,3 +74,36 @@ func TestGitHubStartRequiresConfig(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 }
+
+func TestLogoutClearsSessionCookie(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewServer(store, Config{})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if _, ok, err := store.AccountForWebSession(ctx, token); err != nil || ok {
+		t.Fatalf("session after logout ok=%v err=%v, want false nil", ok, err)
+	}
+}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -160,6 +160,14 @@ func (s *Store) AccountForWebSession(ctx context.Context, token string) (Account
 	return account, true, nil
 }
 
+func (s *Store) DeleteWebSession(ctx context.Context, token string) error {
+	if token == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM web_sessions WHERE token_hash = ?`, sessionHash(token))
+	return err
+}
+
 func (s *Store) UpsertGitHubCache(ctx context.Context, accountID, repo, refID, payloadJSON, etag string, ttl time.Duration) error {
 	if accountID == "" || repo == "" || refID == "" {
 		return errors.New("account id, repo, and ref id are required")

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.13-dev';
+const assetVersion = 'v4.1.14-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -22,6 +22,9 @@ const dom = {
   graphCanvas: document.getElementById('graphCanvas'),
   table: document.getElementById('tableView'),
   githubToken: document.getElementById('githubTokenInput'),
+  backendGithubLogin: document.getElementById('backendGithubLoginBtn'),
+  backendLogout: document.getElementById('backendLogoutBtn'),
+  backendAuthState: document.getElementById('backendAuthState'),
   connectGithub: document.getElementById('connectGithubBtn'),
   pasteGithubToken: document.getElementById('pasteGithubTokenBtn'),
   forgetGithubToken: document.getElementById('forgetGithubTokenBtn'),
@@ -40,6 +43,7 @@ const state = {
   showClosed: true,
   githubRefresh: [],
   githubFailures: [],
+  backendSession: { available: false, authenticated: false, github_oauth_configured: false },
   selectedEdgeID: '',
   graphZoom: 1,
   graphLayout: { width: 900, height: 620 },
@@ -69,6 +73,7 @@ function emptyExport() {
 function boot() {
   dom.githubToken.value = sessionStorage.getItem(githubTokenStorageKey) || '';
   refreshGitHubAuthUI();
+  refreshBackendSession();
   wireEvents();
   setView(readURLView(), { persist: false, renderNow: false });
   const hashed = readHash();
@@ -103,6 +108,8 @@ function wireEvents() {
   document.getElementById('exportBtn').addEventListener('click', exportJSON);
   document.getElementById('fileInput').addEventListener('change', readFile);
   dom.connectGithub.addEventListener('click', connectGitHub);
+  dom.backendGithubLogin.addEventListener('click', signInWithBackendGitHub);
+  dom.backendLogout.addEventListener('click', signOutBackend);
   dom.pasteGithubToken.addEventListener('click', pasteGitHubToken);
   dom.forgetGithubToken.addEventListener('click', forgetGitHubToken);
   dom.githubToken.addEventListener('input', () => {
@@ -172,6 +179,49 @@ function refreshGitHubAuthUI() {
   const connected = Boolean(githubToken());
   dom.githubAuthState.textContent = connected ? 'GitHub: token' : 'GitHub: public';
   dom.forgetGithubToken.disabled = !connected;
+  refreshBackendAuthUI();
+}
+
+async function refreshBackendSession() {
+  try {
+    const res = await fetch('./api/session', { credentials: 'same-origin' });
+    if (!res.ok) throw new Error(String(res.status));
+    state.backendSession = { available: true, ...await res.json() };
+  } catch {
+    state.backendSession = { available: false, authenticated: false, github_oauth_configured: false };
+  }
+  refreshBackendAuthUI();
+}
+
+function refreshBackendAuthUI() {
+  const session = state.backendSession || {};
+  dom.backendGithubLogin.classList.toggle('hidden', !session.available || session.authenticated || !session.github_oauth_configured);
+  dom.backendLogout.classList.toggle('hidden', !session.available || !session.authenticated);
+  dom.backendAuthState.classList.toggle('hidden', !session.available);
+  if (!session.available) {
+    dom.backendAuthState.textContent = '';
+    return;
+  }
+  if (session.authenticated && session.account) {
+    dom.backendAuthState.textContent = `DepViz: @${session.account.login || 'account'}`;
+    return;
+  }
+  dom.backendAuthState.textContent = session.github_oauth_configured ? 'DepViz: signed out' : 'DepViz: local';
+}
+
+function signInWithBackendGitHub() {
+  const returnTo = `${location.pathname}${location.search}${location.hash}`;
+  location.href = `./api/auth/github/start?return_to=${encodeURIComponent(returnTo)}`;
+}
+
+async function signOutBackend() {
+  try {
+    await fetch('./api/auth/logout', { method: 'POST', credentials: 'same-origin' });
+    await refreshBackendSession();
+    dom.status.textContent = 'signed out';
+  } catch {
+    dom.status.textContent = 'sign out failed';
+  }
 }
 
 function connectGitHub() {

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.13-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.14-dev">
 </head>
 <body>
   <header class="topbar">
@@ -14,6 +14,9 @@
     </div>
     <div class="actions">
       <div class="githubAuth" aria-label="GitHub connection">
+        <button id="backendGithubLoginBtn" type="button">Sign in</button>
+        <button id="backendLogoutBtn" type="button">Sign out</button>
+        <span id="backendAuthState" class="tokenState">DepViz: local</span>
         <button id="connectGithubBtn" type="button">Connect GitHub</button>
         <button id="pasteGithubTokenBtn" type="button">Use copied token</button>
         <input id="githubTokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="token fallback" aria-label="GitHub token">
@@ -84,6 +87,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.13-dev"></script>
+  <script src="./app.js?v=v4.1.14-dev"></script>
 </body>
 </html>

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -135,6 +135,33 @@ func TestLiveAssetsExposeGraphZoomControls(t *testing.T) {
 	}
 }
 
+func TestLiveAssetsExposeBackendSessionUI(t *testing.T) {
+	fsys := AppFS()
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"login button", string(index), `id="backendGithubLoginBtn"`},
+		{"logout button", string(index), `id="backendLogoutBtn"`},
+		{"session fetch", string(app), `function refreshBackendSession()`},
+		{"github start", string(app), `./api/auth/github/start`},
+		{"logout api", string(app), `./api/auth/logout`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}
+
 func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
 	fsys := AppFS()
 	app, err := fs.ReadFile(fsys, "app.js")


### PR DESCRIPTION
## Summary
- add backend session awareness to Live without breaking static Pages mode
- show daemon GitHub sign-in/sign-out controls when `/api/session` exists
- add `/api/auth/logout` and session deletion in the backend
- keep browser-only token hydration available as a fallback

## Stack
This is stacked on #697 (`codex/backend-foundation`).

## Manual QA
Backend path:
1. Run `depviz server --addr 127.0.0.1:8766 --base-url http://127.0.0.1:8766`.
2. Open `http://127.0.0.1:8766/`.
3. Expected: the top auth strip shows `DepViz: local` when OAuth env vars are absent.
4. Check `curl -X POST http://127.0.0.1:8766/api/auth/logout` returns `{"ok":true}`.

Static Pages path:
1. Open a Pages preview or serve `live/app/` without the backend.
2. Expected: backend sign-in controls stay hidden and the browser-token GitHub flow still works.

OAuth path after credentials exist:
1. Set GitHub OAuth env vars on the daemon.
2. Open the app and click `Sign in`.
3. Expected: GitHub OAuth redirects back, `/api/session` is authenticated, and `Sign out` clears it.

## Verification
- `/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin/gofmt -w ...`
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
