### PR TITLE
feat: add stateful live mode

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -47,6 +47,7 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/health", s.handleHealth)
 	mux.HandleFunc("/api/session", s.handleSession)
+	mux.HandleFunc("/api/export", s.handleExport)
 	mux.HandleFunc("/api/auth/github/start", s.handleGitHubStart)
 	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubCallback)
 	mux.HandleFunc("/api/auth/logout", s.handleLogout)
@@ -59,6 +60,24 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"ok":                      true,
 		"github_oauth_configured": s.githubOAuthConfigured(),
 	})
+}
+
+func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	board := r.URL.Query().Get("board")
+	if board == "" {
+		board = core.DefaultBoardID
+	}
+	payload, err := s.store.BuildExport(r.Context(), board)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
 }
 
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -56,6 +56,25 @@ func TestHealthAndAnonymousSession(t *testing.T) {
 	if session.Authenticated {
 		t.Fatal("anonymous session is authenticated")
 	}
+
+	res, err = http.Get(ts.URL + "/api/export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	var payload struct {
+		Snapshot struct {
+			Board struct {
+				ID string `json:"id"`
+			} `json:"board"`
+		} `json:"snapshot"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Snapshot.Board.ID != core.DefaultBoardID {
+		t.Fatalf("board id = %q, want %q", payload.Snapshot.Board.ID, core.DefaultBoardID)
+	}
 }
 
 func TestGitHubStartRequiresConfig(t *testing.T) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,10 +1,11 @@
-const assetVersion = 'v4.1.14-dev';
+const assetVersion = 'v4.1.15-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
 const views = new Set(['brief', 'graph', 'table']);
 
 const dom = {
+  shell: document.getElementById('shell'),
   input: document.getElementById('sourceInput'),
   syntax: document.getElementById('syntaxLayer'),
   status: document.getElementById('status'),
@@ -36,6 +37,7 @@ const dom = {
 };
 
 const state = {
+  mode: 'stateless',
   view: 'brief',
   filter: '',
   showExternal: true,
@@ -70,18 +72,24 @@ function emptyExport() {
   };
 }
 
-function boot() {
+async function boot() {
   dom.githubToken.value = sessionStorage.getItem(githubTokenStorageKey) || '';
   refreshGitHubAuthUI();
-  refreshBackendSession();
   wireEvents();
   setView(readURLView(), { persist: false, renderNow: false });
   const hashed = readHash();
   if (hashed) {
+    setMode('stateless', { renderNow: false });
     dom.input.value = hashed;
     update();
     return;
   }
+  await refreshBackendSession();
+  if (state.backendSession.available) {
+    await setMode('stateful', { renderNow: true });
+    return;
+  }
+  setMode('stateless', { renderNow: false });
   loadSample();
 }
 
@@ -101,6 +109,11 @@ function wireEvents() {
   for (const btn of document.querySelectorAll('[data-view]')) {
     btn.addEventListener('click', () => {
       setView(btn.dataset.view, { persist: true, renderNow: true });
+    });
+  }
+  for (const btn of document.querySelectorAll('[data-mode]')) {
+    btn.addEventListener('click', () => {
+      setMode(btn.dataset.mode, { renderNow: true });
     });
   }
   document.getElementById('sampleBtn').addEventListener('click', loadSample);
@@ -142,6 +155,7 @@ function readFile(event) {
 }
 
 function update() {
+  if (state.mode !== 'stateless') return;
   const text = dom.input.value;
   state.githubRefresh = [];
   state.githubFailures = [];
@@ -155,6 +169,42 @@ function update() {
     state.data = emptyExport();
     dom.error.textContent = err.message;
     dom.status.textContent = 'input error';
+  }
+  render();
+}
+
+async function setMode(mode, options = {}) {
+  const next = mode === 'stateful' && state.backendSession.available ? 'stateful' : 'stateless';
+  state.mode = next;
+  document.querySelectorAll('[data-mode]').forEach((item) => {
+    item.classList.toggle('active', item.dataset.mode === next);
+    if (item.dataset.mode === 'stateful') item.disabled = !state.backendSession.available;
+  });
+  dom.shell.classList.toggle('statefulMode', next === 'stateful');
+  document.querySelectorAll('.statelessOnly').forEach((item) => {
+    item.classList.toggle('hidden', next !== 'stateless');
+  });
+  if (next === 'stateful') {
+    await loadBackendBoard();
+    return;
+  }
+  if (options.renderNow !== false) update();
+}
+
+async function loadBackendBoard() {
+  dom.status.textContent = 'loading stateful graph';
+  dom.error.textContent = '';
+  state.githubRefresh = [];
+  state.githubFailures = [];
+  try {
+    const res = await fetch('./api/export?board=default', { credentials: 'same-origin' });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    state.data = normalizeExport(await res.json());
+    dom.status.textContent = 'stateful backend graph';
+  } catch (err) {
+    state.data = emptyExport();
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'stateful load failed';
   }
   render();
 }
@@ -191,6 +241,7 @@ async function refreshBackendSession() {
     state.backendSession = { available: false, authenticated: false, github_oauth_configured: false };
   }
   refreshBackendAuthUI();
+  document.querySelector('[data-mode="stateful"]').disabled = !state.backendSession.available;
 }
 
 function refreshBackendAuthUI() {
@@ -1963,6 +2014,7 @@ function writeURLView(view) {
 }
 
 function shareLink() {
+  if (state.mode !== 'stateless') return;
   const encoded = encodeBase64URL(dom.input.value);
   const url = new URL(location.href);
   url.hash = `data=${encoded}`;

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DepViz Live</title>
-  <link rel="stylesheet" href="./style.css?v=v4.1.14-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.15-dev">
 </head>
 <body>
   <header class="topbar">
@@ -13,6 +13,10 @@
       <span id="status">stateless work graph</span>
     </div>
     <div class="actions">
+      <div class="modeSwitch" role="tablist" aria-label="Mode">
+        <button class="active" data-mode="stateful" type="button">Stateful</button>
+        <button data-mode="stateless" type="button">Stateless</button>
+      </div>
       <div class="githubAuth" aria-label="GitHub connection">
         <button id="backendGithubLoginBtn" type="button">Sign in</button>
         <button id="backendLogoutBtn" type="button">Sign out</button>
@@ -23,14 +27,14 @@
         <button id="forgetGithubTokenBtn" type="button">Forget</button>
         <span id="githubAuthState" class="tokenState">GitHub: public</span>
       </div>
-      <button id="hydrateGithubBtn" type="button">Refresh GitHub</button>
-      <button id="sampleBtn" type="button">Load sample</button>
-      <button id="shareBtn" type="button">Share link</button>
+      <button id="hydrateGithubBtn" class="statelessOnly" type="button">Refresh GitHub</button>
+      <button id="sampleBtn" class="statelessOnly" type="button">Load sample</button>
+      <button id="shareBtn" class="statelessOnly" type="button">Share link</button>
       <button id="exportBtn" type="button">Export JSON</button>
     </div>
   </header>
 
-  <main class="shell">
+  <main id="shell" class="shell">
     <section class="inputPane" aria-label="Input">
       <div class="paneHeader">
         <h1>Input</h1>
@@ -87,6 +91,6 @@
     </section>
   </main>
 
-  <script src="./app.js?v=v4.1.14-dev"></script>
+  <script src="./app.js?v=v4.1.15-dev"></script>
 </body>
 </html>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -92,7 +92,8 @@ button:disabled {
 
 .actions,
 .viewTabs,
-.filters {
+.filters,
+.modeSwitch {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -150,6 +151,14 @@ button:disabled {
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: 10px;
+}
+
+.shell.statefulMode {
+  grid-template-columns: 1fr;
+}
+
+.shell.statefulMode .inputPane {
+  display: none;
 }
 
 .paneHeader,

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -162,6 +162,37 @@ func TestLiveAssetsExposeBackendSessionUI(t *testing.T) {
 	}
 }
 
+func TestLiveAssetsExposeStatefulMode(t *testing.T) {
+	fsys := AppFS()
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	style, err := fs.ReadFile(fsys, "style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"stateful button", string(index), `data-mode="stateful"`},
+		{"stateless button", string(index), `data-mode="stateless"`},
+		{"backend export", string(app), `./api/export?board=default`},
+		{"mode setter", string(app), `async function setMode(`},
+		{"stateful layout", string(style), `.shell.statefulMode`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}
+
 func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
 	fsys := AppFS()
 	app, err := fs.ReadFile(fsys, "app.js")


### PR DESCRIPTION
## Summary
- add a visible Stateful / Stateless mode switch to the single Live page
- make Stateful load the current board from `/api/export?board=default`
- keep share links and static Pages previews in Stateless mode
- hide the editor-only controls while Stateful mode is active
- add `/api/export` on the backend and asset/API coverage

## Stack
This is stacked on #698 (`codex/backend-live-session`).

## Manual QA
Backend path:
1. Open the Tailscale preview or run `depviz server --addr 127.0.0.1:8766 --base-url http://127.0.0.1:8766`.
2. Expected: the page opens in `Stateful` mode when `/api/session` is available.
3. Expected: the left editor pane is hidden and the board renders from `/api/export`.
4. Click `Stateless`.
5. Expected: the editor pane returns, sample/share/refresh controls return, and editing input updates the graph.
6. Open a `#data=...` share link.
7. Expected: the app starts in Stateless mode even when backend APIs exist.

Static path:
1. Open a Pages preview or serve `live/app/` without backend APIs.
2. Expected: Stateful is disabled/falls back to Stateless and the existing editor workflow works.

## Verification
- `/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin/gofmt -w ...`
- `node --check live/app/app.js`
- `PATH=/home/russel/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.11.linux-amd64/bin:$PATH go test ./...`
- `git diff --check`
- loopback smoke for `/api/export`, `/api/session`, index HTML, and app JS
