### PR TITLE
[codex] require auth for stateful GitHub discovery

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -48,6 +48,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/health", s.handleHealth)
 	mux.HandleFunc("/api/session", s.handleSession)
 	mux.HandleFunc("/api/export", s.handleExport)
+	mux.HandleFunc("/api/github/orgs", s.handleGitHubOrgs)
+	mux.HandleFunc("/api/github/projects", s.handleGitHubProjects)
+	mux.HandleFunc("/api/github/repos", s.handleGitHubRepos)
+	mux.HandleFunc("/api/overrides", s.handleOverrides)
 	mux.HandleFunc("/api/auth/github/start", s.handleGitHubStart)
 	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubCallback)
 	mux.HandleFunc("/api/auth/logout", s.handleLogout)
@@ -66,6 +70,9 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if _, ok := s.requireAccount(w, r); !ok {
 		return
 	}
 	board := r.URL.Query().Get("board")
@@ -110,7 +117,7 @@ func (s *Server) handleGitHubStart(w http.ResponseWriter, r *http.Request) {
 	params := url.Values{
 		"client_id":    {s.cfg.GitHubClientID},
 		"redirect_uri": {s.callbackURL()},
-		"scope":        {"repo read:user user:email"},
+		"scope":        {"repo read:user user:email read:org read:project"},
 		"state":        {state},
 	}
 	http.Redirect(w, r, "https://github.com/login/oauth/authorize?"+params.Encode(), http.StatusFound)
@@ -157,6 +164,16 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	workspace, err := s.store.UpsertWorkspace(r.Context(), core.Workspace{
+		Provider:   "github",
+		ExternalID: fmt.Sprint(user.ID),
+		Kind:       "user",
+		Name:       user.Login,
+		URL:        user.HTMLURL,
+	})
+	if err == nil {
+		_ = s.store.UpsertWorkspaceMembership(r.Context(), workspace.ID, account.ID, "owner", "github")
+	}
 	session, expires, err := s.store.CreateWebSession(r.Context(), account.ID, s.cfg.SessionTTL)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -196,12 +213,217 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
+func (s *Server) handleGitHubRepos(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	account, ok := s.requireAccount(w, r)
+	if !ok {
+		return
+	}
+	token, ok := s.githubAccessTokenForAccount(w, r, account.ID)
+	if !ok {
+		return
+	}
+	var repos []githubRepo
+	path := "/user/repos?affiliation=owner,collaborator,organization_member&sort=updated&per_page=100"
+	if err := s.doGitHubREST(r.Context(), token, path, &repos); err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	for _, repo := range repos {
+		raw, _ := json.Marshal(repo)
+		workspace, err := s.store.UpsertWorkspace(r.Context(), core.Workspace{
+			Provider:   "github",
+			ExternalID: fmt.Sprint(repo.ID),
+			Kind:       "repo",
+			Name:       repo.FullName,
+			URL:        repo.HTMLURL,
+			DataJSON:   string(raw),
+		})
+		if err == nil {
+			_ = s.store.UpsertWorkspaceMembership(r.Context(), workspace.ID, account.ID, "member", "github")
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"repos": repos})
+}
+
+func (s *Server) handleGitHubOrgs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	account, ok := s.requireAccount(w, r)
+	if !ok {
+		return
+	}
+	token, ok := s.githubAccessTokenForAccount(w, r, account.ID)
+	if !ok {
+		return
+	}
+	var orgs []githubOrg
+	if err := s.doGitHubREST(r.Context(), token, "/user/orgs?per_page=100", &orgs); err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	for _, org := range orgs {
+		raw, _ := json.Marshal(org)
+		workspace, err := s.store.UpsertWorkspace(r.Context(), core.Workspace{
+			Provider:   "github",
+			ExternalID: fmt.Sprint(org.ID),
+			Kind:       "org",
+			Name:       org.Login,
+			URL:        org.HTMLURL,
+			DataJSON:   string(raw),
+		})
+		if err == nil {
+			_ = s.store.UpsertWorkspaceMembership(r.Context(), workspace.ID, account.ID, "member", "github")
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"orgs": orgs})
+}
+
+func (s *Server) handleGitHubProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	account, ok := s.requireAccount(w, r)
+	if !ok {
+		return
+	}
+	token, ok := s.githubAccessTokenForAccount(w, r, account.ID)
+	if !ok {
+		return
+	}
+	query := `query DepVizProjects {
+		viewer {
+			projectsV2(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+				nodes { id title url updatedAt }
+			}
+			organizations(first: 50) {
+				nodes {
+					login
+					projectsV2(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+						nodes { id title url updatedAt }
+					}
+				}
+			}
+		}
+	}`
+	var gql githubProjectsGraphQL
+	if err := s.doGitHubGraphQL(r.Context(), token, query, &gql); err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	projects := make([]githubProject, 0, len(gql.Viewer.ProjectsV2.Nodes))
+	for _, project := range gql.Viewer.ProjectsV2.Nodes {
+		project.Owner = account.Login
+		projects = append(projects, project)
+	}
+	for _, org := range gql.Viewer.Organizations.Nodes {
+		for _, project := range org.ProjectsV2.Nodes {
+			project.Owner = org.Login
+			projects = append(projects, project)
+		}
+	}
+	for _, project := range projects {
+		raw, _ := json.Marshal(project)
+		workspace, err := s.store.UpsertWorkspace(r.Context(), core.Workspace{
+			Provider:   "github",
+			ExternalID: project.ID,
+			Kind:       "project",
+			Name:       project.Title,
+			URL:        project.URL,
+			DataJSON:   string(raw),
+		})
+		if err == nil {
+			_ = s.store.UpsertWorkspaceMembership(r.Context(), workspace.ID, account.ID, "member", "github")
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"projects": projects})
+}
+
+func (s *Server) handleOverrides(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	account, ok := s.requireAccount(w, r)
+	if !ok {
+		return
+	}
+	var in struct {
+		OwnerType string          `json:"owner_type"`
+		OwnerID   string          `json:"owner_id"`
+		Data      json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if len(in.Data) == 0 {
+		in.Data = json.RawMessage(`{}`)
+	}
+	override, err := s.store.UpsertPersonalOverride(r.Context(), core.PersonalOverride{
+		AccountID: account.ID,
+		OwnerType: in.OwnerType,
+		OwnerID:   in.OwnerID,
+		DataJSON:  string(in.Data),
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"override": override})
+}
+
 func (s *Server) accountForRequest(r *http.Request) (core.Account, bool, error) {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err != nil {
 		return core.Account{}, false, nil
 	}
 	return s.store.AccountForWebSession(r.Context(), cookie.Value)
+}
+
+func (s *Server) requireAccount(w http.ResponseWriter, r *http.Request) (core.Account, bool) {
+	account, ok, err := s.accountForRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return core.Account{}, false
+	}
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "authentication required"})
+		return core.Account{}, false
+	}
+	return account, true
+}
+
+func (s *Server) githubAccessTokenForAccount(w http.ResponseWriter, r *http.Request, accountID string) (string, bool) {
+	conn, ok, err := s.store.OAuthConnectionForAccount(r.Context(), accountID, "github")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return "", false
+	}
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "github account is not connected"})
+		return "", false
+	}
+	var token githubToken
+	if err := json.Unmarshal([]byte(conn.TokenJSON), &token); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "stored github token is unreadable"})
+		return "", false
+	}
+	if token.AccessToken == "" {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "github account is not connected"})
+		return "", false
+	}
+	return token.AccessToken, true
 }
 
 func (s *Server) exchangeGitHubCode(ctx context.Context, code string) (githubToken, error) {
@@ -246,6 +468,41 @@ func (s *Server) fetchGitHubUser(ctx context.Context, accessToken string) (githu
 		return githubUser{}, errors.New("github user response is missing id or login")
 	}
 	return user, nil
+}
+
+func (s *Server) doGitHubREST(ctx context.Context, accessToken, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com"+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	return s.doJSON(req, out)
+}
+
+func (s *Server) doGitHubGraphQL(ctx context.Context, accessToken, query string, out any) error {
+	body, _ := json.Marshal(map[string]string{"query": query})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.github.com/graphql", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := s.doJSON(req, &envelope); err != nil {
+		return err
+	}
+	if len(envelope.Errors) > 0 {
+		return errors.New(envelope.Errors[0].Message)
+	}
+	return json.Unmarshal(envelope.Data, out)
 }
 
 func (s *Server) doJSON(req *http.Request, out any) error {
@@ -305,6 +562,51 @@ type githubUser struct {
 	Name      string `json:"name"`
 	AvatarURL string `json:"avatar_url"`
 	HTMLURL   string `json:"html_url"`
+}
+
+type githubRepo struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	FullName  string `json:"full_name"`
+	Private   bool   `json:"private"`
+	HTMLURL   string `json:"html_url"`
+	UpdatedAt string `json:"updated_at"`
+	Owner     struct {
+		ID    int64  `json:"id"`
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	} `json:"owner"`
+}
+
+type githubOrg struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	HTMLURL   string `json:"html_url"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+type githubProject struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	UpdatedAt string `json:"updated_at"`
+	Owner     string `json:"owner"`
+}
+
+type githubProjectsGraphQL struct {
+	Viewer struct {
+		ProjectsV2 struct {
+			Nodes []githubProject `json:"nodes"`
+		} `json:"projectsV2"`
+		Organizations struct {
+			Nodes []struct {
+				Login      string `json:"login"`
+				ProjectsV2 struct {
+					Nodes []githubProject `json:"nodes"`
+				} `json:"projectsV2"`
+			} `json:"nodes"`
+		} `json:"organizations"`
+	} `json:"viewer"`
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"moul.io/depviz/v4/internal/core"
@@ -62,6 +64,48 @@ func TestHealthAndAnonymousSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("anonymous export status = %d, want %d", res.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthenticatedExport(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/export", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
 	var payload struct {
 		Snapshot struct {
 			Board struct {
@@ -74,6 +118,37 @@ func TestHealthAndAnonymousSession(t *testing.T) {
 	}
 	if payload.Snapshot.Board.ID != core.DefaultBoardID {
 		t.Fatalf("board id = %q, want %q", payload.Snapshot.Board.ID, core.DefaultBoardID)
+	}
+}
+
+func TestGitHubDiscoveryRequiresConnectedOAuth(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+		TokenJSON:  `{}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewServer(store, Config{})
+	req := httptest.NewRequest(http.MethodGet, "/api/github/repos", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 
@@ -91,6 +166,37 @@ func TestGitHubStartRequiresConfig(t *testing.T) {
 	srv.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestGitHubStartRequestsDiscoveryScopes(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	srv := NewServer(store, Config{
+		BaseURL:            "https://depviz.example",
+		GitHubClientID:     "client-id",
+		GitHubClientSecret: "client-secret",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/github/start?return_to=/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	location, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scopes := strings.Fields(location.Query().Get("scope"))
+	for _, want := range []string{"repo", "read:user", "user:email", "read:org", "read:project"} {
+		if !contains(scopes, want) {
+			t.Fatalf("scopes = %v, missing %q", scopes, want)
+		}
 	}
 }
 
@@ -125,4 +231,13 @@ func TestLogoutClearsSessionCookie(t *testing.T) {
 	if _, ok, err := store.AccountForWebSession(ctx, token); err != nil || ok {
 		t.Fatalf("session after logout ok=%v err=%v, want false nil", ok, err)
 	}
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -147,7 +148,10 @@ func (s *Store) AccountForWebSession(ctx context.Context, token string) (Account
 	err := s.db.QueryRowContext(ctx, `SELECT account_id, expires_at FROM web_sessions WHERE token_hash = ?`, sessionHash(token)).
 		Scan(&accountID, &expires)
 	if err != nil {
-		return Account{}, false, nil
+		if errors.Is(err, sql.ErrNoRows) {
+			return Account{}, false, nil
+		}
+		return Account{}, false, err
 	}
 	if exp := parseTime(expires); exp.IsZero() || exp.Before(nowUTC()) {
 		_, _ = s.db.ExecContext(ctx, `DELETE FROM web_sessions WHERE token_hash = ?`, sessionHash(token))
@@ -166,6 +170,107 @@ func (s *Store) DeleteWebSession(ctx context.Context, token string) error {
 	}
 	_, err := s.db.ExecContext(ctx, `DELETE FROM web_sessions WHERE token_hash = ?`, sessionHash(token))
 	return err
+}
+
+func (s *Store) OAuthConnectionForAccount(ctx context.Context, accountID, provider string) (OAuthConnection, bool, error) {
+	if accountID == "" || provider == "" {
+		return OAuthConnection{}, false, nil
+	}
+	var conn OAuthConnection
+	var scopesJSON, created, updated string
+	err := s.db.QueryRowContext(ctx, `SELECT id, account_id, provider, external_id, login, scopes_json, token_json, created_at, updated_at
+		FROM oauth_connections WHERE account_id = ? AND provider = ?`, accountID, provider).
+		Scan(&conn.ID, &conn.AccountID, &conn.Provider, &conn.ExternalID, &conn.Login, &scopesJSON, &conn.TokenJSON, &created, &updated)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return OAuthConnection{}, false, nil
+		}
+		return OAuthConnection{}, false, err
+	}
+	_ = json.Unmarshal([]byte(scopesJSON), &conn.Scopes)
+	conn.CreatedAt = parseTime(created)
+	conn.UpdatedAt = parseTime(updated)
+	return conn, true, nil
+}
+
+func (s *Store) UpsertWorkspace(ctx context.Context, workspace Workspace) (Workspace, error) {
+	workspace.Provider = strings.TrimSpace(workspace.Provider)
+	workspace.ExternalID = strings.TrimSpace(workspace.ExternalID)
+	workspace.Kind = strings.TrimSpace(workspace.Kind)
+	workspace.Name = strings.TrimSpace(workspace.Name)
+	if workspace.Provider == "" || workspace.ExternalID == "" || workspace.Kind == "" || workspace.Name == "" {
+		return Workspace{}, errors.New("provider, external id, kind, and name are required")
+	}
+	if workspace.ID == "" {
+		workspace.ID = stableID("workspace", workspace.Provider, workspace.ExternalID)
+	}
+	if workspace.DataJSON == "" {
+		workspace.DataJSON = `{}`
+	}
+	now := nowUTC()
+	var created string
+	err := s.db.QueryRowContext(ctx, `SELECT created_at FROM workspaces WHERE id = ?`, workspace.ID).Scan(&created)
+	if err != nil {
+		created = formatTime(now)
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO workspaces(id, provider, external_id, kind, name, url, data_json, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(provider, external_id) DO UPDATE SET
+			kind=excluded.kind,
+			name=excluded.name,
+			url=excluded.url,
+			data_json=excluded.data_json,
+			updated_at=excluded.updated_at`,
+		workspace.ID, workspace.Provider, workspace.ExternalID, workspace.Kind, workspace.Name, workspace.URL, workspace.DataJSON, created, formatTime(now))
+	if err != nil {
+		return Workspace{}, err
+	}
+	workspace.CreatedAt = parseTime(created)
+	workspace.UpdatedAt = now
+	return workspace, nil
+}
+
+func (s *Store) UpsertWorkspaceMembership(ctx context.Context, workspaceID, accountID, role, source string) error {
+	if workspaceID == "" || accountID == "" {
+		return errors.New("workspace id and account id are required")
+	}
+	if strings.TrimSpace(role) == "" {
+		role = "member"
+	}
+	if strings.TrimSpace(source) == "" {
+		source = "github"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO workspace_memberships(workspace_id, account_id, role, source, updated_at)
+		VALUES(?, ?, ?, ?, ?)
+		ON CONFLICT(workspace_id, account_id) DO UPDATE SET
+			role=excluded.role,
+			source=excluded.source,
+			updated_at=excluded.updated_at`,
+		workspaceID, accountID, role, source, formatTime(nowUTC()))
+	return err
+}
+
+func (s *Store) UpsertPersonalOverride(ctx context.Context, override PersonalOverride) (PersonalOverride, error) {
+	override.AccountID = strings.TrimSpace(override.AccountID)
+	override.OwnerType = strings.TrimSpace(override.OwnerType)
+	override.OwnerID = strings.TrimSpace(override.OwnerID)
+	if override.AccountID == "" || override.OwnerType == "" || override.OwnerID == "" {
+		return PersonalOverride{}, errors.New("account id, owner type, and owner id are required")
+	}
+	if override.ID == "" {
+		override.ID = stableID("personal-override", override.AccountID, override.OwnerType, override.OwnerID)
+	}
+	if override.DataJSON == "" {
+		override.DataJSON = `{}`
+	}
+	override.UpdatedAt = nowUTC()
+	_, err := s.db.ExecContext(ctx, `INSERT INTO personal_overrides(id, account_id, owner_type, owner_id, data_json, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, owner_type, owner_id) DO UPDATE SET
+			data_json=excluded.data_json,
+			updated_at=excluded.updated_at`,
+		override.ID, override.AccountID, override.OwnerType, override.OwnerID, override.DataJSON, formatTime(override.UpdatedAt))
+	return override, err
 }
 
 func (s *Store) UpsertGitHubCache(ctx context.Context, accountID, repo, refID, payloadJSON, etag string, ttl time.Duration) error {

--- a/internal/core/model.go
+++ b/internal/core/model.go
@@ -111,6 +111,39 @@ type Account struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
+type OAuthConnection struct {
+	ID         string    `json:"id"`
+	AccountID  string    `json:"account_id"`
+	Provider   string    `json:"provider"`
+	ExternalID string    `json:"external_id"`
+	Login      string    `json:"login"`
+	Scopes     []string  `json:"scopes"`
+	TokenJSON  string    `json:"-"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type Workspace struct {
+	ID         string    `json:"id"`
+	Provider   string    `json:"provider"`
+	ExternalID string    `json:"external_id"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	URL        string    `json:"url"`
+	DataJSON   string    `json:"data_json"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type PersonalOverride struct {
+	ID        string    `json:"id"`
+	AccountID string    `json:"account_id"`
+	OwnerType string    `json:"owner_type"`
+	OwnerID   string    `json:"owner_id"`
+	DataJSON  string    `json:"data_json"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 func (n Node) IsClosed() bool {
 	switch strings.ToLower(strings.TrimSpace(n.State)) {
 	case "closed", "done", "merged", "cancelled", "canceled", "resolved":

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -187,6 +187,35 @@ func (s *Store) Migrate(ctx context.Context) error {
 			expires_at TEXT NOT NULL,
 			UNIQUE(account_id, repo, ref_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS workspaces (
+			id TEXT PRIMARY KEY,
+			provider TEXT NOT NULL,
+			external_id TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			name TEXT NOT NULL,
+			url TEXT NOT NULL DEFAULT '',
+			data_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			UNIQUE(provider, external_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS workspace_memberships (
+			workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+			account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			role TEXT NOT NULL DEFAULT 'member',
+			source TEXT NOT NULL DEFAULT 'github',
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY(workspace_id, account_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS personal_overrides (
+			id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			owner_type TEXT NOT NULL,
+			owner_id TEXT NOT NULL,
+			data_json TEXT NOT NULL DEFAULT '{}',
+			updated_at TEXT NOT NULL,
+			UNIQUE(account_id, owner_type, owner_id)
+		)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.ExecContext(ctx, stmt); err != nil {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -192,6 +192,13 @@ async function setMode(mode, options = {}) {
 }
 
 async function loadBackendBoard() {
+  if (!state.backendSession.authenticated) {
+    state.data = emptyExport();
+    dom.status.textContent = state.backendSession.github_oauth_configured ? 'sign in for stateful graph' : 'stateful backend needs oauth config';
+    dom.error.textContent = '';
+    render();
+    return;
+  }
   dom.status.textContent = 'loading stateful graph';
   dom.error.textContent = '';
   state.githubRefresh = [];
@@ -270,6 +277,7 @@ async function signOutBackend() {
     await fetch('./api/auth/logout', { method: 'POST', credentials: 'same-origin' });
     await refreshBackendSession();
     dom.status.textContent = 'signed out';
+    if (state.mode === 'stateful') await loadBackendBoard();
   } catch {
     dom.status.textContent = 'sign out failed';
   }


### PR DESCRIPTION
## What changed

- Requires an authenticated DepViz session before serving the stateful `/api/export` graph.
- Expands GitHub OAuth scopes to include org and project discovery.
- Adds authenticated GitHub discovery endpoints for repos, orgs, and Projects v2 using the stored OAuth token.
- Adds shared workspace and per-account personal override persistence primitives.
- Updates Live stateful mode to show an auth gate instead of fetching backend graph data while signed out.

## Why

Stateful mode needs to be multi-user from the start: GitHub-sourced objects can be shared across users and orgs, while local overrides remain personal to the signed-in account.

## Validation

- `node --check live/app/app.js`
- `go test ./...`
- `git diff --check`
