### PR TITLE
feat: interactive strategy cockpit — editable nodes, delete, strategy types (#704 Phase 1)

### DIFF
--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -170,129 +170,203 @@ func (s *Server) handleBoards(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
 	if _, ok := s.requireAccount(w, r); !ok {
 		return
 	}
-	var in struct {
-		BoardID string `json:"board_id"`
-		Kind    string `json:"kind"`
-		Ref     string `json:"ref"`
-		Title   string `json:"title"`
-	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	boardID := strings.TrimSpace(in.BoardID)
-	if boardID == "" {
-		boardID = core.DefaultBoardID
-	}
-	kind := strings.ToLower(strings.TrimSpace(in.Kind))
-	ref := strings.TrimSpace(in.Ref)
-	title := strings.TrimSpace(in.Title)
-	if kind == "" || kind == "auto" {
-		if _, ok := parseGitHubRef(ref); ok {
-			kind = "github"
-		} else if title != "" {
-			kind = "task"
-		} else {
-			kind = "note"
+	switch r.Method {
+	case http.MethodPost:
+		var in struct {
+			BoardID     string `json:"board_id"`
+			Kind        string `json:"kind"`
+			Ref         string `json:"ref"`
+			Title       string `json:"title"`
+			Status      string `json:"status"`
+			Owner       string `json:"owner"`
+			Description string `json:"description"`
 		}
-	}
-	switch kind {
-	case "github":
-		gh, ok := parseGitHubRef(ref)
-		if !ok {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "expected GitHub URL, owner/repo#123, or owner/repo!123"})
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		node, err := s.store.AddGitHubRefToBoard(r.Context(), boardID, gh.repo, gh.marker, gh.number, title)
+		boardID := strings.TrimSpace(in.BoardID)
+		if boardID == "" {
+			boardID = core.DefaultBoardID
+		}
+		kind := strings.ToLower(strings.TrimSpace(in.Kind))
+		ref := strings.TrimSpace(in.Ref)
+		title := strings.TrimSpace(in.Title)
+		strategyKinds := map[string]bool{
+			"strategy": true, "initiative": true, "bet": true, "project": true,
+			"workstream": true, "risk": true, "decision": true, "question": true,
+			"metric": true,
+		}
+		if kind == "" || kind == "auto" {
+			if _, ok := parseGitHubRef(ref); ok {
+				kind = "github"
+			} else if title != "" {
+				kind = "task"
+			} else {
+				kind = "note"
+			}
+		}
+		switch {
+		case kind == "github":
+			gh, ok := parseGitHubRef(ref)
+			if !ok {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "expected GitHub URL, owner/repo#123, or owner/repo!123"})
+				return
+			}
+			node, err := s.store.AddGitHubRefToBoard(r.Context(), boardID, gh.repo, gh.marker, gh.number, title)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{"node": node})
+		case kind == "note":
+			text := title
+			if text == "" {
+				text = ref
+			}
+			node, err := s.store.CreateNote(r.Context(), boardID, text)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{"node": node})
+		case kind == "task" || strategyKinds[kind]:
+			text := title
+			if text == "" {
+				text = ref
+			}
+			node, err := s.store.CreateStrategyNode(r.Context(), boardID, kind, text, in.Status, in.Owner, in.Description)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{"node": node})
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind must be github, task, note, strategy, initiative, bet, project, workstream, risk, decision, question, metric, or auto"})
+		}
+	case http.MethodPatch:
+		var in struct {
+			NodeID      string `json:"node_id"`
+			Title       string `json:"title"`
+			Status      string `json:"status"`
+			Owner       string `json:"owner"`
+			Description string `json:"description"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		nodeID := strings.TrimSpace(in.NodeID)
+		if nodeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
+			return
+		}
+		node, err := s.store.UpdateNodeFields(r.Context(), nodeID, in.Title, in.Status, in.Owner, in.Description)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusCreated, map[string]any{"node": node})
-	case "note":
-		text := title
-		if text == "" {
-			text = ref
+		writeJSON(w, http.StatusOK, map[string]any{"node": node})
+	case http.MethodDelete:
+		var in struct {
+			BoardID string `json:"board_id"`
+			NodeID  string `json:"node_id"`
 		}
-		node, err := s.store.CreateNote(r.Context(), boardID, text)
-		if err != nil {
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusCreated, map[string]any{"node": node})
-	case "task":
-		text := title
-		if text == "" {
-			text = ref
+		boardID := strings.TrimSpace(in.BoardID)
+		if boardID == "" {
+			boardID = core.DefaultBoardID
 		}
-		node, err := s.store.AddTaskToBoard(r.Context(), boardID, text)
-		if err != nil {
+		nodeID := strings.TrimSpace(in.NodeID)
+		if nodeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
+			return
+		}
+		if err := s.store.RemoveNodeFromBoard(r.Context(), boardID, nodeID); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusCreated, map[string]any{"node": node})
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	default:
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind must be github, task, note, or auto"})
+		w.Header().Set("Allow", "POST, PATCH, DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
 }
 
 func (s *Server) handleBoardLinks(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
 	if _, ok := s.requireAccount(w, r); !ok {
 		return
 	}
-	var in struct {
-		BoardID string `json:"board_id"`
-		From    string `json:"from"`
-		To      string `json:"to"`
-		Kind    string `json:"kind"`
-		Note    string `json:"note"`
+	switch r.Method {
+	case http.MethodPost:
+		var in struct {
+			BoardID string `json:"board_id"`
+			From    string `json:"from"`
+			To      string `json:"to"`
+			Kind    string `json:"kind"`
+			Note    string `json:"note"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		boardID := strings.TrimSpace(in.BoardID)
+		if boardID == "" {
+			boardID = core.DefaultBoardID
+		}
+		snap, err := s.store.Snapshot(r.Context(), boardID)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		from, err := resolveBoardNodeRef(snap, in.From)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "from: " + err.Error()})
+			return
+		}
+		to, err := resolveBoardNodeRef(snap, in.To)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "to: " + err.Error()})
+			return
+		}
+		kind := strings.TrimSpace(in.Kind)
+		if kind == "" {
+			kind = "blocked_by"
+		}
+		edge, err := s.store.AddEdge(r.Context(), boardID, from, to, kind, "user", map[string]any{"note": strings.TrimSpace(in.Note), "source": "manual"})
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"edge": edge})
+	case http.MethodDelete:
+		var in struct {
+			EdgeID string `json:"edge_id"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		edgeID := strings.TrimSpace(in.EdgeID)
+		if edgeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "edge_id is required"})
+			return
+		}
+		if err := s.store.DeleteEdge(r.Context(), edgeID); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	default:
+		w.Header().Set("Allow", "POST, DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	boardID := strings.TrimSpace(in.BoardID)
-	if boardID == "" {
-		boardID = core.DefaultBoardID
-	}
-	snap, err := s.store.Snapshot(r.Context(), boardID)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	from, err := resolveBoardNodeRef(snap, in.From)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "from: " + err.Error()})
-		return
-	}
-	to, err := resolveBoardNodeRef(snap, in.To)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "to: " + err.Error()})
-		return
-	}
-	kind := strings.TrimSpace(in.Kind)
-	if kind == "" {
-		kind = "blocked_by"
-	}
-	edge, err := s.store.AddEdge(r.Context(), boardID, from, to, kind, "user", map[string]any{"note": strings.TrimSpace(in.Note), "source": "manual"})
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	writeJSON(w, http.StatusCreated, map[string]any{"edge": edge})
 }
 
 func (s *Server) handleBoardSync(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -176,13 +176,18 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
 		var in struct {
-			BoardID     string `json:"board_id"`
-			Kind        string `json:"kind"`
-			Ref         string `json:"ref"`
-			Title       string `json:"title"`
-			Status      string `json:"status"`
-			Owner       string `json:"owner"`
-			Description string `json:"description"`
+			BoardID     string   `json:"board_id"`
+			Action      string   `json:"action"`
+			NodeID      string   `json:"node_id"`
+			Kind        string   `json:"kind"`
+			Ref         string   `json:"ref"`
+			Title       string   `json:"title"`
+			Status      string   `json:"status"`
+			Owner       string   `json:"owner"`
+			Description string   `json:"description"`
+			TimeHorizon string   `json:"time_horizon"`
+			Priority    string   `json:"priority"`
+			Labels      []string `json:"labels"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -191,6 +196,30 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 		boardID := strings.TrimSpace(in.BoardID)
 		if boardID == "" {
 			boardID = core.DefaultBoardID
+		}
+		action := strings.TrimSpace(in.Action)
+		if action == "duplicate" {
+			nodeID := strings.TrimSpace(in.NodeID)
+			if nodeID == "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required for duplicate"})
+				return
+			}
+			node, err := s.store.DuplicateNode(r.Context(), boardID, nodeID)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{"node": node})
+			return
+		}
+		if action == "restore" {
+			nodeID := strings.TrimSpace(in.NodeID)
+			if err := s.store.RestoreNode(r.Context(), nodeID); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+			return
 		}
 		kind := strings.ToLower(strings.TrimSpace(in.Kind))
 		ref := strings.TrimSpace(in.Ref)
@@ -238,7 +267,7 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 			if text == "" {
 				text = ref
 			}
-			node, err := s.store.CreateStrategyNode(r.Context(), boardID, kind, text, in.Status, in.Owner, in.Description)
+			node, err := s.store.CreateStrategyNode(r.Context(), boardID, kind, text, in.Status, in.Owner, in.Description, in.TimeHorizon, in.Priority, in.Labels)
 			if err != nil {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 				return
@@ -249,11 +278,15 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 		}
 	case http.MethodPatch:
 		var in struct {
-			NodeID      string `json:"node_id"`
-			Title       string `json:"title"`
-			Status      string `json:"status"`
-			Owner       string `json:"owner"`
-			Description string `json:"description"`
+			NodeID      string   `json:"node_id"`
+			Title       string   `json:"title"`
+			Status      string   `json:"status"`
+			Owner       string   `json:"owner"`
+			Description string   `json:"description"`
+			TimeHorizon string   `json:"time_horizon"`
+			Priority    string   `json:"priority"`
+			Labels      []string `json:"labels"`
+			Kind        string   `json:"kind"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -264,7 +297,16 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
 			return
 		}
-		node, err := s.store.UpdateNodeFields(r.Context(), nodeID, in.Title, in.Status, in.Owner, in.Description)
+		if in.Kind != "" {
+			node, err := s.store.ConvertNodeKind(r.Context(), nodeID, strings.TrimSpace(strings.ToLower(in.Kind)))
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"node": node})
+			return
+		}
+		node, err := s.store.UpdateNodeFields(r.Context(), nodeID, in.Title, in.Status, in.Owner, in.Description, in.TimeHorizon, in.Priority, in.Labels)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -274,6 +316,7 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 		var in struct {
 			BoardID string `json:"board_id"`
 			NodeID  string `json:"node_id"`
+			Soft    bool   `json:"soft"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -288,13 +331,36 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
 			return
 		}
-		if err := s.store.RemoveNodeFromBoard(r.Context(), boardID, nodeID); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
+		if in.Soft {
+			if err := s.store.ArchiveNode(r.Context(), nodeID); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+		} else {
+			if err := s.store.RemoveNodeFromBoard(r.Context(), boardID, nodeID); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
 		}
 		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	case http.MethodGet:
+		boardID := r.URL.Query().Get("board_id")
+		if boardID == "" {
+			boardID = core.DefaultBoardID
+		}
+		archived := r.URL.Query().Get("archived")
+		if archived == "true" {
+			nodes, err := s.store.ListArchivedNodes(r.Context(), boardID)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"nodes": nodes})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "use archived=true"})
 	default:
-		w.Header().Set("Allow", "POST, PATCH, DELETE")
+		w.Header().Set("Allow", "GET, POST, PATCH, DELETE")
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -278,15 +278,15 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 		}
 	case http.MethodPatch:
 		var in struct {
-			NodeID      string   `json:"node_id"`
-			Title       string   `json:"title"`
-			Status      string   `json:"status"`
-			Owner       string   `json:"owner"`
-			Description string   `json:"description"`
-			TimeHorizon string   `json:"time_horizon"`
-			Priority    string   `json:"priority"`
-			Labels      []string `json:"labels"`
-			Kind        string   `json:"kind"`
+			NodeID      string    `json:"node_id"`
+			Title       *string   `json:"title"`
+			Status      *string   `json:"status"`
+			Owner       *string   `json:"owner"`
+			Description *string   `json:"description"`
+			TimeHorizon *string   `json:"time_horizon"`
+			Priority    *string   `json:"priority"`
+			Labels      *[]string `json:"labels"`
+			Kind        string    `json:"kind"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -306,7 +306,15 @@ func (s *Server) handleBoardItems(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, map[string]any{"node": node})
 			return
 		}
-		node, err := s.store.UpdateNodeFields(r.Context(), nodeID, in.Title, in.Status, in.Owner, in.Description, in.TimeHorizon, in.Priority, in.Labels)
+		node, err := s.store.UpdateNodeFields(r.Context(), nodeID, core.NodeFieldUpdate{
+			Title:       in.Title,
+			Status:      in.Status,
+			Owner:       in.Owner,
+			Description: in.Description,
+			TimeHorizon: in.TimeHorizon,
+			Priority:    in.Priority,
+			Labels:      in.Labels,
+		})
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -25,6 +25,16 @@ type Store struct {
 	path string
 }
 
+type NodeFieldUpdate struct {
+	Title       *string
+	Status      *string
+	Owner       *string
+	Description *string
+	TimeHorizon *string
+	Priority    *string
+	Labels      *[]string
+}
+
 func OpenStore(ctx context.Context, path string) (*Store, error) {
 	if path == "" {
 		path = DefaultDBPath
@@ -561,15 +571,15 @@ func (s *Store) BoardMetrics(ctx context.Context, boardID string) (BoardMetrics,
 	var latestNode string
 	err := s.db.QueryRowContext(ctx, `SELECT
 			COUNT(DISTINCT n.id),
-			COUNT(DISTINCT CASE WHEN lower(n.state) NOT IN ('closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved') THEN n.id END),
-			COUNT(DISTINCT CASE WHEN lower(n.state) IN ('closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved') THEN n.id END),
+			COUNT(DISTINCT CASE WHEN lower(n.state) NOT IN ('closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved', 'rejected') THEN n.id END),
+			COUNT(DISTINCT CASE WHEN lower(n.state) IN ('closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved', 'rejected') THEN n.id END),
 			COUNT(DISTINCT CASE WHEN n.kind = 'note' OR n.id LIKE 'note:%' OR bi.local_state != '' THEN n.id END),
 			COUNT(DISTINCT CASE WHEN COALESCE(sr.source_id, '') != '' AND sr.source_id != ? THEN n.id END),
 			COALESCE(MAX(n.updated_at), '')
 		FROM board_items bi
 		JOIN nodes n ON n.id = bi.node_id
 		LEFT JOIN source_refs sr ON sr.node_id = n.id
-		WHERE bi.board_id = ?`, LocalSourceID, boardID).Scan(&m.Items, &m.Open, &m.Closed, &m.Local, &m.External, &latestNode)
+		WHERE bi.board_id = ? AND (n.archived_at IS NULL OR n.archived_at = '')`, LocalSourceID, boardID).Scan(&m.Items, &m.Open, &m.Closed, &m.Local, &m.External, &latestNode)
 	if err != nil {
 		return BoardMetrics{}, err
 	}
@@ -794,23 +804,30 @@ func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, st
 	return n, s.RecordEvent(ctx, "depviz.strategy_node.v1", n.ID, evPayload)
 }
 
-// UpdateNodeFields updates editable fields of a local node.
-// Only non-empty values are applied (pass "" to skip a field).
-func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, owner, description, timeHorizon, priority string, labels []string) (Node, error) {
+// UpdateNodeFields updates editable fields of a node.
+// Nil fields are left untouched; present empty values clear optional fields.
+func (s *Store) UpdateNodeFields(ctx context.Context, nodeID string, update NodeFieldUpdate) (Node, error) {
 	n, err := s.nodeByID(ctx, nodeID)
 	if err != nil {
 		return Node{}, fmt.Errorf("node not found: %w", err)
 	}
-	if title != "" {
-		n.Title = strings.TrimSpace(title)
+	if update.Title != nil {
+		title := strings.TrimSpace(*update.Title)
+		if title == "" {
+			return Node{}, errors.New("title is required")
+		}
+		n.Title = title
 	}
-	if status != "" {
-		n.State = strings.TrimSpace(strings.ToLower(status))
+	if update.Status != nil {
+		status := strings.TrimSpace(strings.ToLower(*update.Status))
+		if status == "" {
+			return Node{}, errors.New("status is required")
+		}
+		n.State = status
 	}
-	if owner != "" {
-		n.Owner = strings.TrimSpace(owner)
+	if update.Owner != nil {
+		n.Owner = strings.TrimSpace(*update.Owner)
 	}
-	// Merge description into data_json
 	var data map[string]any
 	if n.DataJSON != "" {
 		_ = json.Unmarshal([]byte(n.DataJSON), &data)
@@ -818,20 +835,50 @@ func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, own
 	if data == nil {
 		data = map[string]any{}
 	}
-	if description != "" {
-		data["description"] = description
+	if update.Description != nil {
+		description := strings.TrimSpace(*update.Description)
+		if description == "" {
+			delete(data, "description")
+		} else {
+			data["description"] = description
+		}
 	}
-	if owner != "" {
-		data["owner"] = n.Owner
+	if update.Owner != nil {
+		if n.Owner == "" {
+			delete(data, "owner")
+		} else {
+			data["owner"] = n.Owner
+		}
 	}
-	if timeHorizon != "" {
-		data["time_horizon"] = timeHorizon
+	if update.TimeHorizon != nil {
+		timeHorizon := strings.TrimSpace(*update.TimeHorizon)
+		if timeHorizon == "" {
+			delete(data, "time_horizon")
+		} else {
+			data["time_horizon"] = timeHorizon
+		}
 	}
-	if priority != "" {
-		data["priority"] = priority
+	if update.Priority != nil {
+		priority := strings.TrimSpace(*update.Priority)
+		if priority == "" {
+			delete(data, "priority")
+		} else {
+			data["priority"] = priority
+		}
 	}
-	if len(labels) > 0 {
-		data["labels"] = labels
+	if update.Labels != nil {
+		cleaned := make([]string, 0, len(*update.Labels))
+		for _, label := range *update.Labels {
+			label = strings.TrimSpace(label)
+			if label != "" {
+				cleaned = append(cleaned, label)
+			}
+		}
+		if len(cleaned) == 0 {
+			delete(data, "labels")
+		} else {
+			data["labels"] = cleaned
+		}
 	}
 	n.UpdatedAt = nowUTC()
 	merged, _ := json.Marshal(data)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -723,6 +723,161 @@ func (s *Store) AddTaskToBoard(ctx context.Context, boardID, title string) (Node
 	return n, nil
 }
 
+// CreateStrategyNode creates a local non-GitHub planning node with an extended type.
+// kind must be one of: strategy, initiative, bet, project, workstream, risk, decision, question, metric, task, note
+// status must be one of: draft, active, blocked, at-risk, paused, done, rejected, open, closed
+func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, status, owner, description string) (Node, error) {
+	kind = strings.TrimSpace(strings.ToLower(kind))
+	title = strings.TrimSpace(title)
+	status = strings.TrimSpace(strings.ToLower(status))
+	owner = strings.TrimSpace(owner)
+	description = strings.TrimSpace(description)
+	if title == "" {
+		return Node{}, errors.New("title is required")
+	}
+	validKinds := map[string]bool{
+		"strategy": true, "initiative": true, "bet": true, "project": true,
+		"workstream": true, "risk": true, "decision": true, "question": true,
+		"metric": true, "task": true, "note": true,
+	}
+	if !validKinds[kind] {
+		kind = "task"
+	}
+	if status == "" {
+		if kind == "note" {
+			status = "local"
+		} else {
+			status = "draft"
+		}
+	}
+	prefix := kind + ":"
+	id, err := s.availableNodeID(ctx, prefix+slug(title))
+	if err != nil {
+		return Node{}, err
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"source":      "local",
+		"kind":        kind,
+		"text":        title,
+		"description": description,
+		"owner":       owner,
+	})
+	n := Node{
+		ID:        id,
+		Kind:      kind,
+		Title:     title,
+		State:     status,
+		Owner:     owner,
+		DataJSON:  string(payload),
+		UpdatedAt: nowUTC(),
+	}
+	if err := s.UpsertNode(ctx, n); err != nil {
+		return Node{}, err
+	}
+	if err := s.UpsertSourceRef(ctx, n.ID, LocalSourceID, n.ID, ""); err != nil {
+		return Node{}, err
+	}
+	role := "card"
+	if kind == "note" {
+		role = "note"
+	}
+	if err := s.AddNodeToBoard(ctx, boardID, n.ID, role, "local"); err != nil {
+		return Node{}, err
+	}
+	evPayload, _ := json.Marshal(n)
+	return n, s.RecordEvent(ctx, "depviz.strategy_node.v1", n.ID, evPayload)
+}
+
+// UpdateNodeFields updates editable fields of a local node.
+// Only non-empty values are applied (pass "" to skip a field).
+func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, owner, description string) (Node, error) {
+	n, err := s.nodeByID(ctx, nodeID)
+	if err != nil {
+		return Node{}, fmt.Errorf("node not found: %w", err)
+	}
+	if title != "" {
+		n.Title = strings.TrimSpace(title)
+	}
+	if status != "" {
+		n.State = strings.TrimSpace(strings.ToLower(status))
+	}
+	if owner != "" {
+		n.Owner = strings.TrimSpace(owner)
+	}
+	// Merge description into data_json
+	var data map[string]any
+	if n.DataJSON != "" {
+		_ = json.Unmarshal([]byte(n.DataJSON), &data)
+	}
+	if data == nil {
+		data = map[string]any{}
+	}
+	if description != "" {
+		data["description"] = description
+	}
+	if owner != "" {
+		data["owner"] = n.Owner
+	}
+	n.UpdatedAt = nowUTC()
+	merged, _ := json.Marshal(data)
+	n.DataJSON = string(merged)
+	if err := s.UpsertNode(ctx, n); err != nil {
+		return Node{}, err
+	}
+	evPayload, _ := json.Marshal(n)
+	return n, s.RecordEvent(ctx, "depviz.node_update.v1", n.ID, evPayload)
+}
+
+// RemoveNodeFromBoard removes a node from a board. If the node is local-only and has no
+// other board references, it is also deleted from the nodes table.
+func (s *Store) RemoveNodeFromBoard(ctx context.Context, boardID, nodeID string) error {
+	if boardID == "" {
+		boardID = DefaultBoardID
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM board_items WHERE board_id = ? AND node_id = ?`, boardID, nodeID)
+	if err != nil {
+		return err
+	}
+	// Also delete edges scoped to this board that reference the node
+	_, err = s.db.ExecContext(ctx, `DELETE FROM edges WHERE scope_board_id = ? AND (from_id = ? OR to_id = ?)`, boardID, nodeID, nodeID)
+	if err != nil {
+		return err
+	}
+	// If local node and no other board references, delete from nodes too
+	isLocal := strings.HasPrefix(nodeID, "note:") || strings.HasPrefix(nodeID, "task:") ||
+		strings.HasPrefix(nodeID, "strategy:") || strings.HasPrefix(nodeID, "initiative:") ||
+		strings.HasPrefix(nodeID, "bet:") || strings.HasPrefix(nodeID, "project:") ||
+		strings.HasPrefix(nodeID, "workstream:") || strings.HasPrefix(nodeID, "risk:") ||
+		strings.HasPrefix(nodeID, "decision:") || strings.HasPrefix(nodeID, "question:") ||
+		strings.HasPrefix(nodeID, "metric:")
+	if isLocal {
+		var count int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM board_items WHERE node_id = ?`, nodeID).Scan(&count); err == nil && count == 0 {
+			_, _ = s.db.ExecContext(ctx, `DELETE FROM source_refs WHERE node_id = ?`, nodeID)
+			_, _ = s.db.ExecContext(ctx, `DELETE FROM nodes WHERE id = ?`, nodeID)
+		}
+	}
+	payload, _ := json.Marshal(map[string]any{"board_id": boardID, "node_id": nodeID})
+	return s.RecordEvent(ctx, "depviz.node_remove.v1", nodeID, payload)
+}
+
+// DeleteEdge removes an edge by ID.
+func (s *Store) DeleteEdge(ctx context.Context, edgeID string) error {
+	if edgeID == "" {
+		return errors.New("edge id is required")
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM edges WHERE id = ?`, edgeID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return errors.New("edge not found")
+	}
+	payload, _ := json.Marshal(map[string]any{"edge_id": edgeID})
+	return s.RecordEvent(ctx, "depviz.edge_delete.v1", edgeID, payload)
+}
+
 func (s *Store) AddGitHubRefToBoard(ctx context.Context, boardID, repo, marker, number, title string) (Node, error) {
 	repo = strings.TrimSpace(repo)
 	marker = strings.TrimSpace(marker)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -235,6 +235,8 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return err
 		}
 	}
+	// Additive migrations (ALTER TABLE — idempotent via ignored errors)
+	_, _ = s.db.ExecContext(ctx, `ALTER TABLE nodes ADD COLUMN archived_at TEXT`)
 	return nil
 }
 
@@ -353,7 +355,7 @@ func (s *Store) CreateNote(ctx context.Context, boardID, text string) (Node, err
 	if err != nil {
 		return Node{}, err
 	}
-	payload, _ := json.Marshal(map[string]any{"source": "local", "text": text})
+	payload, _ := json.Marshal(map[string]any{"source": "local", "text": text, "created_at": formatTime(nowUTC())})
 	n := Node{
 		ID:        id,
 		Kind:      "note",
@@ -699,7 +701,7 @@ func (s *Store) AddTaskToBoard(ctx context.Context, boardID, title string) (Node
 	if err != nil {
 		return Node{}, err
 	}
-	payload, _ := json.Marshal(map[string]any{"source": "local", "text": title})
+	payload, _ := json.Marshal(map[string]any{"source": "local", "text": title, "created_at": formatTime(nowUTC())})
 	n := Node{
 		ID:        id,
 		Kind:      "task",
@@ -726,7 +728,7 @@ func (s *Store) AddTaskToBoard(ctx context.Context, boardID, title string) (Node
 // CreateStrategyNode creates a local non-GitHub planning node with an extended type.
 // kind must be one of: strategy, initiative, bet, project, workstream, risk, decision, question, metric, task, note
 // status must be one of: draft, active, blocked, at-risk, paused, done, rejected, open, closed
-func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, status, owner, description string) (Node, error) {
+func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, status, owner, description, timeHorizon, priority string, labels []string) (Node, error) {
 	kind = strings.TrimSpace(strings.ToLower(kind))
 	title = strings.TrimSpace(title)
 	status = strings.TrimSpace(strings.ToLower(status))
@@ -756,11 +758,15 @@ func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, st
 		return Node{}, err
 	}
 	payload, _ := json.Marshal(map[string]any{
-		"source":      "local",
-		"kind":        kind,
-		"text":        title,
-		"description": description,
-		"owner":       owner,
+		"source":       "local",
+		"kind":         kind,
+		"text":         title,
+		"description":  description,
+		"owner":        owner,
+		"time_horizon": timeHorizon,
+		"priority":     priority,
+		"labels":       labels,
+		"created_at":   formatTime(nowUTC()),
 	})
 	n := Node{
 		ID:        id,
@@ -790,7 +796,7 @@ func (s *Store) CreateStrategyNode(ctx context.Context, boardID, kind, title, st
 
 // UpdateNodeFields updates editable fields of a local node.
 // Only non-empty values are applied (pass "" to skip a field).
-func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, owner, description string) (Node, error) {
+func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, owner, description, timeHorizon, priority string, labels []string) (Node, error) {
 	n, err := s.nodeByID(ctx, nodeID)
 	if err != nil {
 		return Node{}, fmt.Errorf("node not found: %w", err)
@@ -817,6 +823,15 @@ func (s *Store) UpdateNodeFields(ctx context.Context, nodeID, title, status, own
 	}
 	if owner != "" {
 		data["owner"] = n.Owner
+	}
+	if timeHorizon != "" {
+		data["time_horizon"] = timeHorizon
+	}
+	if priority != "" {
+		data["priority"] = priority
+	}
+	if len(labels) > 0 {
+		data["labels"] = labels
 	}
 	n.UpdatedAt = nowUTC()
 	merged, _ := json.Marshal(data)
@@ -878,6 +893,109 @@ func (s *Store) DeleteEdge(ctx context.Context, edgeID string) error {
 	return s.RecordEvent(ctx, "depviz.edge_delete.v1", edgeID, payload)
 }
 
+// DuplicateNode creates a copy of an existing node with "Copy of " prefix.
+func (s *Store) DuplicateNode(ctx context.Context, boardID, nodeID string) (Node, error) {
+	src, err := s.nodeByID(ctx, nodeID)
+	if err != nil {
+		return Node{}, fmt.Errorf("source node not found: %w", err)
+	}
+	var data map[string]any
+	_ = json.Unmarshal([]byte(src.DataJSON), &data)
+	if data == nil {
+		data = map[string]any{}
+	}
+	description, _ := data["description"].(string)
+	timeHorizon, _ := data["time_horizon"].(string)
+	priority, _ := data["priority"].(string)
+	var labelsList []string
+	if ls, ok := data["labels"].([]interface{}); ok {
+		for _, l := range ls {
+			if lStr, ok := l.(string); ok {
+				labelsList = append(labelsList, lStr)
+			}
+		}
+	}
+	return s.CreateStrategyNode(ctx, boardID, src.Kind, "Copy of "+src.Title, src.State, src.Owner, description, timeHorizon, priority, labelsList)
+}
+
+// ConvertNodeKind changes the kind of a local node.
+func (s *Store) ConvertNodeKind(ctx context.Context, nodeID, newKind string) (Node, error) {
+	n, err := s.nodeByID(ctx, nodeID)
+	if err != nil {
+		return Node{}, fmt.Errorf("node not found: %w", err)
+	}
+	validKinds := map[string]bool{
+		"strategy": true, "initiative": true, "bet": true, "project": true,
+		"workstream": true, "risk": true, "decision": true, "question": true,
+		"metric": true, "task": true, "note": true,
+	}
+	if !validKinds[newKind] {
+		return Node{}, errors.New("invalid kind")
+	}
+	n.Kind = newKind
+	n.UpdatedAt = nowUTC()
+	var data map[string]any
+	_ = json.Unmarshal([]byte(n.DataJSON), &data)
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["kind"] = newKind
+	merged, _ := json.Marshal(data)
+	n.DataJSON = string(merged)
+	if err := s.UpsertNode(ctx, n); err != nil {
+		return Node{}, err
+	}
+	evPayload, _ := json.Marshal(n)
+	return n, s.RecordEvent(ctx, "depviz.node_convert.v1", n.ID, evPayload)
+}
+
+// ArchiveNode soft-archives a node by setting archived_at.
+func (s *Store) ArchiveNode(ctx context.Context, nodeID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE nodes SET archived_at = ? WHERE id = ?`, formatTime(nowUTC()), nodeID)
+	if err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(map[string]any{"node_id": nodeID})
+	return s.RecordEvent(ctx, "depviz.node_archive.v1", nodeID, payload)
+}
+
+// RestoreNode clears the archived_at field, making the node visible again.
+func (s *Store) RestoreNode(ctx context.Context, nodeID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE nodes SET archived_at = NULL WHERE id = ?`, nodeID)
+	if err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(map[string]any{"node_id": nodeID})
+	return s.RecordEvent(ctx, "depviz.node_restore.v1", nodeID, payload)
+}
+
+// ListArchivedNodes returns nodes that have been soft-archived on a board.
+func (s *Store) ListArchivedNodes(ctx context.Context, boardID string) ([]Node, error) {
+	if boardID == "" {
+		boardID = DefaultBoardID
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT n.id, n.kind, n.title, n.state, n.owner, n.data_json, n.updated_at
+		FROM board_items bi
+		JOIN nodes n ON n.id = bi.node_id
+		WHERE bi.board_id = ? AND n.archived_at IS NOT NULL AND n.archived_at != ''
+		ORDER BY n.updated_at DESC`, boardID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var nodes []Node
+	for rows.Next() {
+		var n Node
+		var updated string
+		if err := rows.Scan(&n.ID, &n.Kind, &n.Title, &n.State, &n.Owner, &n.DataJSON, &updated); err != nil {
+			return nil, err
+		}
+		n.UpdatedAt = parseTime(updated)
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
 func (s *Store) AddGitHubRefToBoard(ctx context.Context, boardID, repo, marker, number, title string) (Node, error) {
 	repo = strings.TrimSpace(repo)
 	marker = strings.TrimSpace(marker)
@@ -932,7 +1050,7 @@ func (s *Store) Snapshot(ctx context.Context, boardID string) (Snapshot, error) 
 		FROM board_items bi
 		JOIN nodes n ON n.id = bi.node_id
 		LEFT JOIN source_refs sr ON sr.node_id = n.id
-		WHERE bi.board_id = ?
+		WHERE bi.board_id = ? AND (n.archived_at IS NULL OR n.archived_at = '')
 		GROUP BY n.id
 		ORDER BY n.updated_at DESC, n.id`, boardID)
 	if err != nil {

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -128,5 +129,77 @@ func TestIngestEventPreservesEdgeConfidence(t *testing.T) {
 	}
 	if snap.Edges[0].Authority != "github-inferred" {
 		t.Fatalf("authority = %q, want github-inferred", snap.Edges[0].Authority)
+	}
+}
+
+func TestUpdateNodeFieldsCanClearOptionalFields(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	labels := []string{"strategy", "urgent"}
+	node, err := s.CreateStrategyNode(ctx, DefaultBoardID, "strategy", "Shape DepViz cockpit", "active", "moul", "Original description", "now", "high", labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty := ""
+	title := "Shape DepViz cockpit"
+	status := "active"
+	emptyLabels := []string{}
+	updated, err := s.UpdateNodeFields(ctx, node.ID, NodeFieldUpdate{
+		Title:       &title,
+		Status:      &status,
+		Owner:       &empty,
+		Description: &empty,
+		TimeHorizon: &empty,
+		Priority:    &empty,
+		Labels:      &emptyLabels,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Owner != "" {
+		t.Fatalf("owner = %q, want empty", updated.Owner)
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(updated.DataJSON), &data); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"owner", "description", "time_horizon", "priority", "labels"} {
+		if _, ok := data[key]; ok {
+			t.Fatalf("data[%q] still present after clear: %+v", key, data)
+		}
+	}
+}
+
+func TestBoardMetricsIgnoreArchivedNodes(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	node, err := s.CreateStrategyNode(ctx, DefaultBoardID, "task", "Temporary plan", "active", "", "", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := s.BoardMetrics(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Items != 1 || before.Open != 1 {
+		t.Fatalf("before metrics = %+v, want one open item", before)
+	}
+	if err := s.ArchiveNode(ctx, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	after, err := s.BoardMetrics(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Items != 0 || after.Open != 0 || after.Closed != 0 {
+		t.Fatalf("after metrics = %+v, want no visible items", after)
 	}
 }

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -2898,6 +2898,7 @@ function renderEdgeInspector(snapshot) {
       <div class="edgeActions">
         ${suggestionActions}
         <button type="button" data-edge-action="locate">Locate in graph</button>
+        <button type="button" class="dangerAction" data-edge-action="delete-edge">Delete link</button>
         <button type="button" data-edge-action="clear">Clear</button>
       </div>
     </div>
@@ -3133,6 +3134,28 @@ function handleEdgeInspectorClick(event) {
   }
   if (button.dataset.edgeAction === 'promote') promoteSuggestedEdge(edgeID);
   if (button.dataset.edgeAction === 'hide') dismissSuggestedEdge(edgeID);
+  if (button.dataset.edgeAction === 'delete-edge') deleteLinkFromBoard(edgeID);
+}
+
+async function deleteLinkFromBoard(edgeID) {
+  if (!edgeID) return;
+  const edge = edgeByID(edgeID);
+  if (!confirm(`Delete this link (${edge ? relationLabel(edge.kind) : edgeID})?`)) return;
+  try {
+    const res = await fetch('./api/board-links', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ edge_id: edgeID }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res));
+    state.selectedEdgeID = '';
+    await loadBackendBoard();
+    dom.status.textContent = 'link deleted';
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'delete failed';
+  }
 }
 
 function handleSuggestionClick(event) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -48,6 +48,9 @@ const dom = {
   newItemKind: document.getElementById('newItemKind'),
   newItemRef: document.getElementById('newItemRef'),
   newItemTitle: document.getElementById('newItemTitle'),
+  newItemStatus: document.getElementById('newItemStatus'),
+  newItemOwner: document.getElementById('newItemOwner'),
+  newItemDescription: document.getElementById('newItemDescription'),
   newLinkFrom: document.getElementById('newLinkFrom'),
   newLinkKind: document.getElementById('newLinkKind'),
   newLinkTo: document.getElementById('newLinkTo'),
@@ -389,6 +392,9 @@ async function addBoardItem(event) {
     dom.newItemRef.focus();
     return;
   }
+  const status = dom.newItemStatus ? dom.newItemStatus.value.trim() : '';
+  const owner = dom.newItemOwner ? dom.newItemOwner.value.trim() : '';
+  const description = dom.newItemDescription ? dom.newItemDescription.value.trim() : '';
   try {
     const res = await fetch('./api/board-items', {
       method: 'POST',
@@ -399,11 +405,17 @@ async function addBoardItem(event) {
         kind: dom.newItemKind.value,
         ref,
         title,
+        status,
+        owner,
+        description,
       }),
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     dom.newItemRef.value = '';
     dom.newItemTitle.value = '';
+    if (dom.newItemStatus) dom.newItemStatus.value = '';
+    if (dom.newItemOwner) dom.newItemOwner.value = '';
+    if (dom.newItemDescription) dom.newItemDescription.value = '';
     await loadBackendBoard();
     await refreshBoards();
     dom.status.textContent = 'item added';
@@ -3458,7 +3470,9 @@ function nodeCardClasses(node) {
 function nodeKindLabel(node) {
   if (node.kind === 'pr') return 'PR';
   if (node.kind === 'issue') return 'Issue';
-  if (isLocal(node)) return 'Note';
+  const strategyKinds = new Set(['strategy', 'initiative', 'bet', 'project', 'workstream', 'risk', 'decision', 'question', 'metric']);
+  if (strategyKinds.has(node.kind)) return capitalize(node.kind);
+  if (isLocal(node)) return capitalize(node.kind || 'Note');
   return capitalize(node.kind || 'Task');
 }
 
@@ -3504,7 +3518,12 @@ function lifecycleBadge(value) {
   const lifecycle = String(value || 'unknown').toLowerCase();
   if (lifecycle === 'merged') return badge('life-merged', '🟣 merged');
   if (lifecycle === 'draft') return badge('life-draft', '🚧 draft');
+  if (lifecycle === 'active') return badge('life-active', '🟢 active');
   if (lifecycle === 'open') return badge('life-open', '🟢 open');
+  if (lifecycle === 'blocked') return badge('life-blocked', '🔴 blocked');
+  if (lifecycle === 'at-risk') return badge('life-atrisk', '🟡 at-risk');
+  if (lifecycle === 'paused') return badge('life-paused', '⏸ paused');
+  if (lifecycle === 'rejected') return badge('life-rejected', '❌ rejected');
   if (isClosed({ state: lifecycle })) return badge('life-closed', '⚫ closed');
   if (lifecycle === 'local') return badge('life-local', '📝 local');
   return badge('life-unknown', '◇ unknown');
@@ -3590,11 +3609,13 @@ function nodeData(node) {
 }
 
 function isClosed(node) {
-  return ['closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved'].includes(String(node.state || '').toLowerCase());
+  return ['closed', 'done', 'merged', 'cancelled', 'canceled', 'resolved', 'rejected'].includes(String(node.state || '').toLowerCase());
 }
 
 function isLocal(node) {
-  return node.kind === 'note' || String(node.id || '').startsWith('note:');
+  const localPrefixes = ['note:', 'task:', 'strategy:', 'initiative:', 'bet:', 'project:',
+    'workstream:', 'risk:', 'decision:', 'question:', 'metric:'];
+  return node.kind === 'note' || localPrefixes.some((p) => String(node.id || '').startsWith(p));
 }
 
 function isPlaceholder(node) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -2,7 +2,7 @@ const assetVersion = 'v4.1.15-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
-const views = new Set(['brief', 'graph', 'table']);
+const views = new Set(['brief', 'graph', 'table', 'kanban']);
 
 const dom = {
   shell: document.getElementById('shell'),
@@ -67,6 +67,13 @@ const dom = {
   showLocal: document.getElementById('showLocal'),
   showClosed: document.getElementById('showClosed'),
   filterChips: document.getElementById('filterChips'),
+  newItemTimeHorizon: document.getElementById('newItemTimeHorizon'),
+  newItemPriority: document.getElementById('newItemPriority'),
+  newItemLabels: document.getElementById('newItemLabels'),
+  newLinkNotes: document.getElementById('newLinkNotes'),
+  bulkImportText: document.getElementById('bulkImportText'),
+  bulkImportKind: document.getElementById('bulkImportKind'),
+  kanban: document.getElementById('kanbanView'),
 };
 
 const state = {
@@ -96,6 +103,7 @@ const state = {
   activeChipFilters: new Set(),
   data: emptyExport(),
   inspectorEditMode: false,
+  undoStack: [],
 };
 
 function emptyExport() {
@@ -217,6 +225,39 @@ function wireEvents() {
     });
   }
   document.addEventListener('keydown', handleGraphKeydown);
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+      e.preventDefault();
+      undoLastOp();
+      return;
+    }
+    if (inputFocused()) return;
+    if (e.key === 'n') {
+      e.preventDefault();
+      setWorkspaceTab('actions');
+      setTimeout(() => (dom.newItemTitle || dom.newItemRef).focus(), 50);
+      return;
+    }
+    if (e.key === 'l') {
+      e.preventDefault();
+      setWorkspaceTab('actions');
+      setTimeout(() => dom.newLinkFrom.focus(), 50);
+      return;
+    }
+    if (e.key === '/' || e.key === 's') {
+      e.preventDefault();
+      if (dom.filter) dom.filter.focus();
+      return;
+    }
+    if (e.key === 'Escape') {
+      if (state.selectedNodeID) {
+        state.selectedNodeID = '';
+        state.inspectorEditMode = false;
+        render();
+      }
+    }
+  });
+  document.getElementById('bulkImportForm')?.addEventListener('submit', handleBulkImport);
 }
 
 async function loadSample() {
@@ -396,6 +437,10 @@ async function addBoardItem(event) {
   const status = dom.newItemStatus ? dom.newItemStatus.value.trim() : '';
   const owner = dom.newItemOwner ? dom.newItemOwner.value.trim() : '';
   const description = dom.newItemDescription ? dom.newItemDescription.value.trim() : '';
+  const timeHorizon = dom.newItemTimeHorizon ? dom.newItemTimeHorizon.value : '';
+  const priority = dom.newItemPriority ? dom.newItemPriority.value : '';
+  const labelsRaw = dom.newItemLabels ? dom.newItemLabels.value.trim() : '';
+  const itemLabels = labelsRaw ? labelsRaw.split(',').map((l) => l.trim()).filter(Boolean) : [];
   try {
     const res = await fetch('./api/board-items', {
       method: 'POST',
@@ -409,14 +454,23 @@ async function addBoardItem(event) {
         status,
         owner,
         description,
+        time_horizon: timeHorizon,
+        priority,
+        labels: itemLabels,
       }),
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const addPayload = await res.json();
+    const newNodeID = addPayload.node?.id || '';
+    if (newNodeID) pushUndo({ type: 'add-node', nodeID: newNodeID });
     dom.newItemRef.value = '';
     dom.newItemTitle.value = '';
     if (dom.newItemStatus) dom.newItemStatus.value = '';
     if (dom.newItemOwner) dom.newItemOwner.value = '';
     if (dom.newItemDescription) dom.newItemDescription.value = '';
+    if (dom.newItemTimeHorizon) dom.newItemTimeHorizon.value = '';
+    if (dom.newItemPriority) dom.newItemPriority.value = '';
+    if (dom.newItemLabels) dom.newItemLabels.value = '';
     await loadBackendBoard();
     await refreshBoards();
     dom.status.textContent = 'item added';
@@ -445,11 +499,13 @@ async function addBoardLink(event) {
         from,
         to,
         kind: dom.newLinkKind.value,
+        notes: dom.newLinkNotes ? dom.newLinkNotes.value.trim() : '',
       }),
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     dom.newLinkFrom.value = '';
     dom.newLinkTo.value = '';
+    if (dom.newLinkNotes) dom.newLinkNotes.value = '';
     await loadBackendBoard();
     await refreshBoards();
     dom.status.textContent = 'link added';
@@ -624,6 +680,9 @@ function renderManagePanel() {
   if (state.githubPresets.loaded) renderGitHubPresets();
   renderDebugPanel();
   renderWorkspaceSuggestions();
+  if (state.mode === 'stateful' && state.backendSession.authenticated) {
+    loadArchivedNodes();
+  }
 }
 
 function renderBoardListButton(board) {
@@ -1960,9 +2019,11 @@ function render() {
   dom.brief.classList.toggle('hidden', state.view !== 'brief');
   dom.graph.classList.toggle('hidden', state.view !== 'graph');
   dom.table.classList.toggle('hidden', state.view !== 'table');
+  if (dom.kanban) dom.kanban.classList.toggle('hidden', state.view !== 'kanban');
   if (state.view === 'brief') renderBrief(brief);
   if (state.view === 'graph') renderGraph(snapshot, graphSelection.nodes, graphSelection.hidden);
   if (state.view === 'table') renderTable(nodes);
+  if (state.view === 'kanban') renderKanbanView();
 }
 
 function renderStats(counts, snapshot) {
@@ -2940,10 +3001,12 @@ function renderItemInspector(snapshot) {
   const kindBadgeHTML = `<span class="badge type-${esc(badgeClass(node.kind || 'task'))}">${esc(nodeKindLabel(node))}</span>`;
   const stateBadge = lifecycleBadge(node.state);
   const stateBadgeHTML = stateBadge ? `<span class="badge ${esc(stateBadge.kind)}">${esc(stateBadge.text)}</span>` : '';
+  const timeHorizonBadgeHTML = data.time_horizon ? `<span class="badge horizon-${esc(data.time_horizon)}">${esc(data.time_horizon)}</span>` : '';
+  const priorityBadgeHTML = data.priority ? `<span class="badge priority-${esc(data.priority)}">${esc(data.priority)}</span>` : '';
   const editBtn = local ? `<button type="button" data-item-action="edit">Edit</button>` : '';
   const headSection = `<div class="inspectorHead">
     <div>
-      <div class="inspectorBadges">${kindBadgeHTML}${stateBadgeHTML}</div>
+      <div class="inspectorBadges">${kindBadgeHTML}${stateBadgeHTML}${timeHorizonBadgeHTML}${priorityBadgeHTML}</div>
       <strong>${emojiHTML(node.title || node.id)}</strong>
     </div>
     <div>
@@ -2951,10 +3014,13 @@ function renderItemInspector(snapshot) {
       <button type="button" data-item-action="close">×</button>
     </div>
   </div>`;
+  const createdAt = data.created_at ? ` · Created ${formatDate(data.created_at)}` : '';
+  const updatedAt = node.updated_at ? ` · Updated ${formatDate(node.updated_at)}` : '';
   const metaSection = `<div class="inspectorMeta">
     <span>${esc(node.id)}</span>
     ${node.owner ? `<span>@${esc(node.owner)}</span>` : ''}
     ${github ? `<span>${esc(github.repo)}</span>` : ''}
+    ${(createdAt || updatedAt) ? `<span class="inspectorDates">${esc((createdAt + updatedAt).trim())}</span>` : ''}
   </div>`;
   const labelsSection = labelsHTML ? `<div class="inspectorLabels">${labelsHTML}</div>` : '';
   const descriptionSection = data.description ? `<div class="inspectorDescription">${emojiHTML(data.description)}</div>` : '';
@@ -2975,16 +3041,57 @@ function renderItemInspector(snapshot) {
     </label>
     <label>Owner<input type="text" name="owner" value="${esc(node.owner || '')}"></label>
     <label>Description<textarea name="description" rows="3">${esc(data.description || '')}</textarea></label>
+    <label>Time horizon
+      <select name="time_horizon">
+        <option value="">No horizon</option>
+        <option value="now"${data.time_horizon === 'now' ? ' selected' : ''}>Now</option>
+        <option value="next"${data.time_horizon === 'next' ? ' selected' : ''}>Next</option>
+        <option value="later"${data.time_horizon === 'later' ? ' selected' : ''}>Later</option>
+        <option value="quarter"${data.time_horizon === 'quarter' ? ' selected' : ''}>This quarter</option>
+        <option value="year"${data.time_horizon === 'year' ? ' selected' : ''}>This year</option>
+        <option value="someday"${data.time_horizon === 'someday' ? ' selected' : ''}>Someday</option>
+      </select>
+    </label>
+    <label>Priority
+      <select name="priority">
+        <option value="">No priority</option>
+        <option value="critical"${data.priority === 'critical' ? ' selected' : ''}>Critical</option>
+        <option value="high"${data.priority === 'high' ? ' selected' : ''}>High</option>
+        <option value="medium"${data.priority === 'medium' ? ' selected' : ''}>Medium</option>
+        <option value="low"${data.priority === 'low' ? ' selected' : ''}>Low</option>
+      </select>
+    </label>
+    <label>Labels<input type="text" name="labels" value="${esc((data.labels || []).join(', '))}"></label>
+    <label>Convert to
+      <select name="convert_kind">
+        <option value="">Keep current (${esc(node.kind)})</option>
+        <option value="strategy">Strategy</option>
+        <option value="initiative">Initiative</option>
+        <option value="bet">Bet</option>
+        <option value="project">Project</option>
+        <option value="workstream">Workstream</option>
+        <option value="risk">Risk</option>
+        <option value="decision">Decision</option>
+        <option value="question">Question</option>
+        <option value="metric">Metric</option>
+        <option value="task">Task</option>
+        <option value="note">Note</option>
+      </select>
+    </label>
     <div class="inspectorFormActions">
       <button type="submit" class="primaryAction">Save</button>
       <button type="button" data-item-action="cancel-edit">Cancel</button>
     </div>
   </form>` : '';
+  const duplicateBtn = local ? `<button type="button" data-item-action="duplicate">Duplicate</button>` : '';
+  const deleteLabel = local ? 'Archive' : 'Remove';
+  const deleteAction = local ? 'archive-node' : 'delete-node';
   const actionsSection = `<div class="inspectorActions">
     ${node.url ? `<a href="${esc(node.url)}" target="_blank" rel="noreferrer">Open GitHub</a>` : ''}
     <button type="button" data-item-action="link-from">Link from</button>
     <button type="button" data-item-action="link-to">Link to</button>
-    <button type="button" class="dangerAction" data-item-action="delete-node">Remove</button>
+    ${duplicateBtn}
+    <button type="button" class="dangerAction" data-item-action="${deleteAction}">${esc(deleteLabel)}</button>
   </div>`;
   dom.itemInspector.innerHTML = `<section class="inspectorBox">
     ${headSection}
@@ -3052,6 +3159,14 @@ function handleItemInspectorClick(event) {
     deleteNodeFromBoard(state.selectedNodeID);
     return;
   }
+  if (button.dataset.itemAction === 'archive-node') {
+    archiveNodeFromBoard(state.selectedNodeID);
+    return;
+  }
+  if (button.dataset.itemAction === 'duplicate') {
+    duplicateNode(state.selectedNodeID);
+    return;
+  }
   if (button.dataset.itemAction === 'link-from') {
     dom.newLinkFrom.value = node.id;
     setWorkspaceTab('actions');
@@ -3070,7 +3185,30 @@ async function saveNodeEdit() {
   const nodeID = state.selectedNodeID;
   if (!nodeID) return;
   const data = Object.fromEntries(new FormData(form));
+  const beforeNode = nodeByID(nodeID);
+  const beforeNodeData = nodeData(beforeNode || {});
+  const beforeData = {
+    title: beforeNode?.title || '',
+    status: beforeNode?.state || '',
+    owner: beforeNode?.owner || '',
+    description: beforeNodeData.description || '',
+    time_horizon: beforeNodeData.time_horizon || '',
+    priority: beforeNodeData.priority || '',
+    labels: beforeNodeData.labels || [],
+  };
   try {
+    // If convert_kind is set, do a kind conversion first
+    if (data.convert_kind) {
+      const res2 = await fetch('./api/board-items', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ node_id: nodeID, kind: data.convert_kind }),
+      });
+      if (!res2.ok) throw new Error(await responseErrorMessage(res2));
+    }
+    const labelsStr = data.labels || '';
+    const labelsList = labelsStr ? labelsStr.split(',').map((l) => l.trim()).filter(Boolean) : [];
     const res = await fetch('./api/board-items', {
       method: 'PATCH',
       credentials: 'same-origin',
@@ -3081,9 +3219,13 @@ async function saveNodeEdit() {
         status: data.status || '',
         owner: data.owner || '',
         description: data.description || '',
+        time_horizon: data.time_horizon || '',
+        priority: data.priority || '',
+        labels: labelsList,
       }),
     });
     if (!res.ok) throw new Error(await responseErrorMessage(res));
+    pushUndo({ type: 'edit-node', nodeID, before: beforeData });
     state.inspectorEditMode = false;
     await loadBackendBoard();
     dom.status.textContent = 'node updated';
@@ -3099,6 +3241,7 @@ async function deleteNodeFromBoard(nodeID) {
   const label = node ? (node.title || node.id) : nodeID;
   if (!confirm(`Remove "${label.slice(0, 60)}" from this board?`)) return;
   try {
+    const nodeSnap = node;
     const res = await fetch('./api/board-items', {
       method: 'DELETE',
       credentials: 'same-origin',
@@ -3106,6 +3249,7 @@ async function deleteNodeFromBoard(nodeID) {
       body: JSON.stringify({ board_id: state.currentBoardID || 'default', node_id: nodeID }),
     });
     if (!res.ok) throw new Error(await responseErrorMessage(res));
+    if (nodeSnap) pushUndo({ type: 'remove-node', snapshot: nodeSnap });
     state.selectedNodeID = '';
     state.selectedEdgeID = '';
     state.inspectorEditMode = false;
@@ -3115,6 +3259,30 @@ async function deleteNodeFromBoard(nodeID) {
   } catch (err) {
     dom.error.textContent = err.message;
     dom.status.textContent = 'remove failed';
+  }
+}
+
+async function archiveNodeFromBoard(nodeID) {
+  if (!nodeID) return;
+  const node = nodeByID(nodeID);
+  const label = node ? (node.title || node.id) : nodeID;
+  if (!confirm(`Archive "${label.slice(0, 60)}"? You can restore it later.`)) return;
+  try {
+    const res = await fetch('./api/board-items', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ board_id: state.currentBoardID || 'default', node_id: nodeID, soft: true }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res));
+    pushUndo({ type: 'restore-node', nodeID });
+    state.selectedNodeID = '';
+    state.inspectorEditMode = false;
+    await loadBackendBoard();
+    dom.status.textContent = 'node archived';
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'archive failed';
   }
 }
 
@@ -3142,6 +3310,7 @@ async function deleteLinkFromBoard(edgeID) {
   const edge = edgeByID(edgeID);
   if (!confirm(`Delete this link (${edge ? relationLabel(edge.kind) : edgeID})?`)) return;
   try {
+    const edgeSnap = edge;
     const res = await fetch('./api/board-links', {
       method: 'DELETE',
       credentials: 'same-origin',
@@ -3149,6 +3318,7 @@ async function deleteLinkFromBoard(edgeID) {
       body: JSON.stringify({ edge_id: edgeID }),
     });
     if (!res.ok) throw new Error(await responseErrorMessage(res));
+    if (edgeSnap) pushUndo({ type: 'delete-link', snapshot: edgeSnap });
     state.selectedEdgeID = '';
     await loadBackendBoard();
     dom.status.textContent = 'link deleted';
@@ -3436,7 +3606,8 @@ function visibleNodes(nodes) {
     if (!state.showClosed && isClosed(node)) return false;
     if (!state.showLocal && isLocal(node)) return false;
     if (!state.showExternal && !isLocal(node)) return false;
-    const hay = [node.id, node.title, node.state, node.kind, badgeText(nodeBadges(node)), labels(node).join(' '), nodePeople(node).map((person) => person.login).join(' '), nodeData(node).milestone || ''].join(' ').toLowerCase();
+    const nd = nodeData(node);
+    const hay = [node.id, node.title, node.state, node.kind, badgeText(nodeBadges(node)), labels(node).join(' '), nodePeople(node).map((person) => person.login).join(' '), nd.milestone || '', nd.description || '', nd.owner || '', nd.time_horizon || '', nd.priority || ''].join(' ').toLowerCase();
     if (state.filter && !hay.includes(state.filter)) return false;
     if (state.activeChipFilters.size > 0) {
       const byType = {};
@@ -3903,6 +4074,244 @@ function esc(value) {
     '"': '&quot;',
     "'": '&#39;',
   })[char]);
+}
+
+// --- Commit B: undo stack ---
+
+function pushUndo(op) {
+  state.undoStack.push(op);
+  if (state.undoStack.length > 20) state.undoStack.shift();
+}
+
+async function undoLastOp() {
+  const op = state.undoStack.pop();
+  if (!op) { dom.status.textContent = 'nothing to undo'; return; }
+  try {
+    if (op.type === 'add-node') {
+      await fetch('./api/board-items', {
+        method: 'DELETE', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ board_id: state.currentBoardID || 'default', node_id: op.nodeID }),
+      });
+    } else if (op.type === 'remove-node') {
+      const nd = nodeData(op.snapshot || {});
+      await fetch('./api/board-items', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          board_id: state.currentBoardID || 'default',
+          kind: op.snapshot.kind || 'task',
+          title: op.snapshot.title || '',
+          status: op.snapshot.state || '',
+          owner: op.snapshot.owner || '',
+          description: nd.description || '',
+        }),
+      });
+    } else if (op.type === 'edit-node') {
+      await fetch('./api/board-items', {
+        method: 'PATCH', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ node_id: op.nodeID, ...op.before }),
+      });
+    } else if (op.type === 'delete-link') {
+      await fetch('./api/board-links', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          board_id: state.currentBoardID || 'default',
+          from: op.snapshot.from_id,
+          to: op.snapshot.to_id,
+          kind: op.snapshot.kind,
+        }),
+      });
+    } else if (op.type === 'restore-node') {
+      await fetch('./api/board-items', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'restore', node_id: op.nodeID }),
+      });
+    }
+    await loadBackendBoard();
+    dom.status.textContent = `undone: ${op.type.replace(/-/g, ' ')}`;
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'undo failed';
+  }
+}
+
+// --- Commit C: keyboard helpers ---
+
+function inputFocused() {
+  const t = document.activeElement?.tagName?.toLowerCase();
+  return t === 'input' || t === 'textarea' || t === 'select' || Boolean(document.activeElement?.isContentEditable);
+}
+
+// --- Commit D: duplicate node ---
+
+async function duplicateNode(nodeID) {
+  try {
+    const res = await fetch('./api/board-items', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'duplicate', board_id: state.currentBoardID || 'default', node_id: nodeID }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res));
+    const payload = await res.json();
+    const newID = payload.node?.id || '';
+    if (newID) pushUndo({ type: 'add-node', nodeID: newID });
+    await loadBackendBoard();
+    dom.status.textContent = 'node duplicated';
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'duplicate failed';
+  }
+}
+
+// --- Commit E: bulk import ---
+
+async function handleBulkImport(e) {
+  e.preventDefault();
+  const raw = dom.bulkImportText ? dom.bulkImportText.value.trim() : '';
+  if (!raw) return;
+  const defaultKind = dom.bulkImportKind ? dom.bulkImportKind.value || 'task' : 'task';
+  const lines = raw.split('\n').map((l) => l.trim()).filter(Boolean);
+  const tasks = lines.map((line) => {
+    let kind = defaultKind;
+    let title = line;
+    let done = false;
+    const checkboxMatch = line.match(/^[-*]\s+\[([x ])\]\s+(.+)$/i);
+    if (checkboxMatch) {
+      done = checkboxMatch[1].toLowerCase() === 'x';
+      title = checkboxMatch[2];
+    } else {
+      title = line.replace(/^[-*#•]\s+/, '');
+    }
+    const kindPrefixMatch = title.match(/^(strategy|initiative|bet|project|workstream|risk|decision|question|metric|task|note):\s+(.+)$/i);
+    if (kindPrefixMatch) {
+      kind = kindPrefixMatch[1].toLowerCase();
+      title = kindPrefixMatch[2];
+    }
+    return { kind, title, status: done ? 'done' : '' };
+  });
+  const boardID = state.currentBoardID || 'default';
+  let created = 0;
+  for (const t of tasks) {
+    try {
+      const res = await fetch('./api/board-items', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ board_id: boardID, kind: t.kind, title: t.title, status: t.status }),
+      });
+      if (res.ok) created++;
+    } catch (_) {}
+  }
+  if (dom.bulkImportText) dom.bulkImportText.value = '';
+  await loadBackendBoard();
+  dom.status.textContent = `${created} node${created !== 1 ? 's' : ''} imported`;
+}
+
+// --- Commit F: kanban view ---
+
+function renderKanbanView() {
+  const el = document.getElementById('kanbanView');
+  if (!el) return;
+  const lanes = [
+    { status: 'draft', label: '🚧 Draft' },
+    { status: 'active', label: '🟢 Active' },
+    { status: 'open', label: '🟢 Open' },
+    { status: 'blocked', label: '🔴 Blocked' },
+    { status: 'at-risk', label: '🟡 At-risk' },
+    { status: 'paused', label: '⏸ Paused' },
+    { status: 'local', label: '📝 Local' },
+    { status: 'done', label: '⚫ Done' },
+    { status: 'closed', label: '⚫ Closed' },
+    { status: 'rejected', label: '❌ Rejected' },
+  ];
+  const nodes = visibleNodes(state.data.snapshot.nodes);
+  if (!nodes.length) {
+    el.innerHTML = '<div class="emptyState"><p>No items to show.</p></div>';
+    return;
+  }
+  const byStatus = {};
+  for (const n of nodes) {
+    const s = (n.state || 'local').toLowerCase();
+    if (!byStatus[s]) byStatus[s] = [];
+    byStatus[s].push(n);
+  }
+  const laneStatuses = new Set(lanes.map((l) => l.status));
+  for (const s of Object.keys(byStatus)) {
+    if (!laneStatuses.has(s)) lanes.push({ status: s, label: capitalize(s) });
+  }
+  const activeLanes = lanes.filter((l) => byStatus[l.status]?.length > 0);
+  if (!activeLanes.length) {
+    el.innerHTML = '<div class="emptyState"><p>No items to show.</p></div>';
+    return;
+  }
+  el.innerHTML = `<div class="kanbanBoard">${activeLanes.map((lane) => {
+    const cards = byStatus[lane.status] || [];
+    return `<div class="kanbanLane">
+      <div class="kanbanLaneHead"><strong>${esc(lane.label)}</strong><span class="kanbanCount">${cards.length}</span></div>
+      <div class="kanbanCards">${cards.map((n) => `
+        <div class="kanbanCard${state.selectedNodeID === n.id ? ' selected' : ''}" data-node-id="${esc(n.id)}">
+          <div class="kanbanCardKind">${esc(nodeKindLabel(n))}</div>
+          <div class="kanbanCardTitle">${emojiHTML(n.title || n.id)}</div>
+          ${n.owner ? `<div class="kanbanCardOwner">@${esc(n.owner)}</div>` : ''}
+        </div>`).join('')}
+      </div>
+    </div>`;
+  }).join('')}</div>`;
+  el.querySelectorAll('[data-node-id]').forEach((card) => {
+    card.addEventListener('click', () => {
+      state.selectedNodeID = card.dataset.nodeId;
+      render();
+    });
+  });
+}
+
+// --- Commit I: date formatting ---
+
+function formatDate(v) {
+  if (!v) return '';
+  try {
+    const d = new Date(v);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('en', { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch { return String(v); }
+}
+
+// --- Commit J: load archived nodes ---
+
+async function loadArchivedNodes() {
+  const container = document.getElementById('archivedNodesList');
+  if (!container) return;
+  try {
+    const board = encodeURIComponent(state.currentBoardID || 'default');
+    const res = await fetch(`./api/board-items?board_id=${board}&archived=true`, { credentials: 'same-origin' });
+    if (!res.ok) return;
+    const payload = await res.json();
+    const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    if (!nodes.length) {
+      container.innerHTML = '<div class="emptyState" style="padding:8px">No archived nodes</div>';
+      return;
+    }
+    container.innerHTML = nodes.map((n) => `<div class="archivedNode">
+      <span>${esc(n.title || n.id)}</span>
+      <button type="button" data-restore-id="${esc(n.id)}">Restore</button>
+    </div>`).join('');
+    container.querySelectorAll('[data-restore-id]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const res2 = await fetch('./api/board-items', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'restore', node_id: btn.dataset.restoreId }),
+        });
+        if (res2.ok) {
+          await loadBackendBoard();
+          dom.status.textContent = 'node restored';
+        }
+      });
+    });
+  } catch (_) {}
 }
 
 boot();

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -95,6 +95,7 @@ const state = {
   dismissedSuggestionIDs: new Set(),
   activeChipFilters: new Set(),
   data: emptyExport(),
+  inspectorEditMode: false,
 };
 
 function emptyExport() {
@@ -2934,26 +2935,63 @@ function renderItemInspector(snapshot) {
   const data = nodeData(node);
   const github = parseGitHubNodeID(node.id);
   const labelsHTML = labels(node).slice(0, 10).map((label) => `<span>${emojiHTML(label)}</span>`).join('');
-  dom.itemInspector.innerHTML = `<section class="inspectorBox">
-    <div class="inspectorHead">
-      <div>
-        <span>${esc(node.kind || 'item')}</span>
-        <strong>${emojiHTML(node.title || node.id)}</strong>
-      </div>
+  const local = isLocal(node);
+  const kindBadgeHTML = `<span class="badge type-${esc(badgeClass(node.kind || 'task'))}">${esc(nodeKindLabel(node))}</span>`;
+  const stateBadge = lifecycleBadge(node.state);
+  const stateBadgeHTML = stateBadge ? `<span class="badge ${esc(stateBadge.kind)}">${esc(stateBadge.text)}</span>` : '';
+  const editBtn = local ? `<button type="button" data-item-action="edit">Edit</button>` : '';
+  const headSection = `<div class="inspectorHead">
+    <div>
+      <div class="inspectorBadges">${kindBadgeHTML}${stateBadgeHTML}</div>
+      <strong>${emojiHTML(node.title || node.id)}</strong>
+    </div>
+    <div>
+      ${editBtn}
       <button type="button" data-item-action="close">×</button>
     </div>
-    <div class="inspectorMeta">
-      <span>${esc(node.id)}</span>
-      <span>${esc(node.state || 'unknown')}</span>
-      ${node.owner ? `<span>@${esc(node.owner)}</span>` : ''}
-      ${github ? `<span>${esc(github.repo)}</span>` : ''}
+  </div>`;
+  const metaSection = `<div class="inspectorMeta">
+    <span>${esc(node.id)}</span>
+    ${node.owner ? `<span>@${esc(node.owner)}</span>` : ''}
+    ${github ? `<span>${esc(github.repo)}</span>` : ''}
+  </div>`;
+  const labelsSection = labelsHTML ? `<div class="inspectorLabels">${labelsHTML}</div>` : '';
+  const descriptionSection = data.description ? `<div class="inspectorDescription">${emojiHTML(data.description)}</div>` : '';
+  const editFormSection = local && state.inspectorEditMode ? `<form class="inspectorEditForm" id="inspectorEditForm">
+    <label>Title<input type="text" name="title" value="${esc(node.title || '')}"></label>
+    <label>Status
+      <select name="status">
+        <option value="draft"${node.state === 'draft' ? ' selected' : ''}>Draft</option>
+        <option value="active"${node.state === 'active' ? ' selected' : ''}>Active</option>
+        <option value="blocked"${node.state === 'blocked' ? ' selected' : ''}>Blocked</option>
+        <option value="at-risk"${node.state === 'at-risk' ? ' selected' : ''}>At-risk</option>
+        <option value="paused"${node.state === 'paused' ? ' selected' : ''}>Paused</option>
+        <option value="open"${node.state === 'open' ? ' selected' : ''}>Open</option>
+        <option value="done"${node.state === 'done' ? ' selected' : ''}>Done</option>
+        <option value="rejected"${node.state === 'rejected' ? ' selected' : ''}>Rejected</option>
+        <option value="local"${node.state === 'local' ? ' selected' : ''}>Local</option>
+      </select>
+    </label>
+    <label>Owner<input type="text" name="owner" value="${esc(node.owner || '')}"></label>
+    <label>Description<textarea name="description" rows="3">${esc(data.description || '')}</textarea></label>
+    <div class="inspectorFormActions">
+      <button type="submit" class="primaryAction">Save</button>
+      <button type="button" data-item-action="cancel-edit">Cancel</button>
     </div>
-    ${labelsHTML ? `<div class="inspectorLabels">${labelsHTML}</div>` : ''}
-    <div class="inspectorActions">
-      ${node.url ? `<a href="${esc(node.url)}" target="_blank" rel="noreferrer">Open GitHub</a>` : ''}
-      <button type="button" data-item-action="link-from">Link from</button>
-      <button type="button" data-item-action="link-to">Link to</button>
-    </div>
+  </form>` : '';
+  const actionsSection = `<div class="inspectorActions">
+    ${node.url ? `<a href="${esc(node.url)}" target="_blank" rel="noreferrer">Open GitHub</a>` : ''}
+    <button type="button" data-item-action="link-from">Link from</button>
+    <button type="button" data-item-action="link-to">Link to</button>
+    <button type="button" class="dangerAction" data-item-action="delete-node">Remove</button>
+  </div>`;
+  dom.itemInspector.innerHTML = `<section class="inspectorBox">
+    ${headSection}
+    ${metaSection}
+    ${labelsSection}
+    ${descriptionSection}
+    ${editFormSection}
+    ${actionsSection}
     <div class="inspectorSection">
       <h3>Links</h3>
       ${renderInspectorLinks('Out', outgoing)}
@@ -2964,6 +3002,11 @@ function renderItemInspector(snapshot) {
       <pre>${esc(JSON.stringify(data, null, 2))}</pre>
     </details>
   </section>`;
+  // Wire edit form submit via delegation
+  const editForm = document.getElementById('inspectorEditForm');
+  if (editForm) {
+    editForm.addEventListener('submit', (e) => { e.preventDefault(); saveNodeEdit(); });
+  }
 }
 
 function renderInspectorLinks(label, edges) {
@@ -2988,11 +3031,26 @@ function handleItemInspectorClick(event) {
   if (!button) return;
   if (button.dataset.itemAction === 'close') {
     state.selectedNodeID = '';
+    state.inspectorEditMode = false;
+    render();
+    return;
+  }
+  if (button.dataset.itemAction === 'edit') {
+    state.inspectorEditMode = true;
+    render();
+    return;
+  }
+  if (button.dataset.itemAction === 'cancel-edit') {
+    state.inspectorEditMode = false;
     render();
     return;
   }
   const node = nodeByID(state.selectedNodeID);
   if (!node) return;
+  if (button.dataset.itemAction === 'delete-node') {
+    deleteNodeFromBoard(state.selectedNodeID);
+    return;
+  }
   if (button.dataset.itemAction === 'link-from') {
     dom.newLinkFrom.value = node.id;
     setWorkspaceTab('actions');
@@ -3002,6 +3060,60 @@ function handleItemInspectorClick(event) {
     dom.newLinkTo.value = node.id;
     setWorkspaceTab('actions');
     dom.newLinkFrom.focus();
+  }
+}
+
+async function saveNodeEdit() {
+  const form = document.getElementById('inspectorEditForm');
+  if (!form) return;
+  const nodeID = state.selectedNodeID;
+  if (!nodeID) return;
+  const data = Object.fromEntries(new FormData(form));
+  try {
+    const res = await fetch('./api/board-items', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        node_id: nodeID,
+        title: data.title || '',
+        status: data.status || '',
+        owner: data.owner || '',
+        description: data.description || '',
+      }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res));
+    state.inspectorEditMode = false;
+    await loadBackendBoard();
+    dom.status.textContent = 'node updated';
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'update failed';
+  }
+}
+
+async function deleteNodeFromBoard(nodeID) {
+  if (!nodeID) return;
+  const node = nodeByID(nodeID);
+  const label = node ? (node.title || node.id) : nodeID;
+  if (!confirm(`Remove "${label.slice(0, 60)}" from this board?`)) return;
+  try {
+    const res = await fetch('./api/board-items', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ board_id: state.currentBoardID || 'default', node_id: nodeID }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res));
+    state.selectedNodeID = '';
+    state.selectedEdgeID = '';
+    state.inspectorEditMode = false;
+    await loadBackendBoard();
+    await refreshBoards();
+    dom.status.textContent = 'node removed';
+  } catch (err) {
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'remove failed';
   }
 }
 

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -3614,15 +3614,24 @@ function nodeKindLabel(node) {
 function nodeReferenceLabel(node) {
   const ref = parseGitHubNodeID(node.id);
   if (ref) return `${ref.marker}${ref.number}`;
-  if (String(node.id || '').startsWith('note:')) return 'local';
-  return String(node.id || '').replace(/^gh:/, '').slice(0, 28);
+  const id = String(node.id || '');
+  if (id.startsWith('note:') || id.startsWith('task:')) return 'local';
+  const strategyPrefixes = ['strategy:', 'initiative:', 'bet:', 'project:', 'workstream:', 'risk:', 'decision:', 'question:', 'metric:'];
+  if (strategyPrefixes.some((p) => id.startsWith(p))) return 'local';
+  return id.replace(/^gh:/, '').slice(0, 28);
 }
 
 function nodeBadges(node) {
   const data = nodeData(node);
   const badges = [];
+  const strategyKinds = new Set(['strategy', 'initiative', 'bet', 'project', 'workstream', 'risk', 'decision', 'question', 'metric']);
+  if (strategyKinds.has(node.kind)) {
+    badges.push(typeBadge(node));
+    badges.push(lifecycleBadge(node.state));
+    return badges.filter(Boolean);
+  }
   if (isLocal(node)) {
-    badges.push(badge('type-local', 'note'));
+    badges.push(badge('type-local', node.kind === 'task' ? '▣ task' : 'note'));
     return badges;
   }
   badges.push(typeBadge(node));
@@ -3646,6 +3655,8 @@ function typeBadge(node) {
   if (kind === 'pr') return badge('type-pr', 'PR');
   if (kind === 'issue') return badge('type-issue', 'issue');
   if (kind === 'note') return badge('type-local', 'note');
+  const strategyKinds = new Set(['strategy', 'initiative', 'bet', 'project', 'workstream', 'risk', 'decision', 'question', 'metric']);
+  if (strategyKinds.has(kind)) return badge(`type-${kind}`, capitalize(kind));
   return badge('type-task', '▣ task');
 }
 

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -68,6 +68,7 @@
           <button data-view="brief" type="button">Overview</button>
           <button class="active" data-view="graph" type="button">Relations</button>
           <button data-view="table" type="button">Table</button>
+          <button data-view="kanban" type="button">Board</button>
         </div>
       </div>
 
@@ -107,6 +108,10 @@
               <input id="newBoardDescription" type="text" autocomplete="off" placeholder="Description" aria-label="New view description">
               <button type="submit">Create</button>
             </form>
+            <details id="archivedSection">
+              <summary>Archived nodes</summary>
+              <div id="archivedNodesList"></div>
+            </details>
           </section>
 
           <section id="workspaceActions" class="workspaceTab hidden">
@@ -149,6 +154,23 @@
               </select>
               <input id="newItemOwner" type="text" autocomplete="off" placeholder="Owner (optional)" aria-label="New item owner">
               <textarea id="newItemDescription" rows="2" placeholder="Description (optional)" aria-label="New item description"></textarea>
+              <select id="newItemTimeHorizon" aria-label="Time horizon">
+                <option value="">No horizon</option>
+                <option value="now">Now</option>
+                <option value="next">Next</option>
+                <option value="later">Later</option>
+                <option value="quarter">This quarter</option>
+                <option value="year">This year</option>
+                <option value="someday">Someday</option>
+              </select>
+              <select id="newItemPriority" aria-label="Priority">
+                <option value="">No priority</option>
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+              <input id="newItemLabels" type="text" autocomplete="off" placeholder="Labels (comma-separated)" aria-label="Labels">
               <button class="primaryAction" type="submit">Add item</button>
             </form>
 
@@ -161,8 +183,25 @@
                 <option value="addresses">addresses</option>
               </select>
               <input id="newLinkTo" type="text" autocomplete="off" placeholder="To: #702, title, or node id" aria-label="Link to item">
+              <input id="newLinkNotes" type="text" autocomplete="off" placeholder="Notes (optional)" aria-label="Link notes" style="grid-column: 1 / -1;">
               <button type="submit">Add link</button>
             </form>
+
+            <details class="bulkImport">
+              <summary>Bulk import from text</summary>
+              <form id="bulkImportForm" class="quickAddForm">
+                <label for="bulkImportText">Paste lines — each becomes a node.</label>
+                <textarea id="bulkImportText" rows="5" placeholder="- Strategy: expand market&#10;- Risk: budget&#10;- [ ] Define OKRs" aria-label="Bulk import text"></textarea>
+                <select id="bulkImportKind" aria-label="Default kind">
+                  <option value="task">Task</option>
+                  <option value="note">Note</option>
+                  <option value="initiative">Initiative</option>
+                  <option value="risk">Risk</option>
+                  <option value="decision">Decision</option>
+                </select>
+                <button type="submit" class="primaryAction">Import nodes</button>
+              </form>
+            </details>
           </section>
 
           <section id="workspacePresets" class="workspaceTab hidden">
@@ -217,6 +256,7 @@
             <label><input id="showClosed" type="checkbox" checked> Closed</label>
           </div>
           <div id="filterChips" class="filterChips"></div>
+          <div class="keyHints">n · New&nbsp;&nbsp;l · Link&nbsp;&nbsp;/ · Search&nbsp;&nbsp;⌘Z · Undo</div>
           <div class="stats" id="stats"></div>
         </div>
 
@@ -244,6 +284,7 @@
               <div id="graphCanvas" class="graphCanvas"></div>
             </div>
             <div id="tableView" class="view hidden"></div>
+            <div id="kanbanView" class="view hidden"></div>
           </div>
           <aside id="itemInspector" class="itemInspector statefulOnly hidden" aria-label="Item inspector"></aside>
         </div>

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -120,11 +120,35 @@
               <select id="newItemKind" aria-label="New item kind">
                 <option value="auto">Auto</option>
                 <option value="github">GitHub issue/PR</option>
-                <option value="task">Task</option>
-                <option value="note">Note</option>
+                <optgroup label="Strategy">
+                  <option value="strategy">Strategy</option>
+                  <option value="initiative">Initiative</option>
+                  <option value="bet">Bet</option>
+                  <option value="project">Project</option>
+                  <option value="workstream">Workstream</option>
+                  <option value="risk">Risk</option>
+                  <option value="decision">Decision</option>
+                  <option value="question">Question</option>
+                  <option value="metric">Metric</option>
+                </optgroup>
+                <optgroup label="Local">
+                  <option value="task">Task</option>
+                  <option value="note">Note</option>
+                </optgroup>
               </select>
               <input id="newItemRef" type="text" autocomplete="off" placeholder="Issue, PR, URL, or task" aria-label="New item reference">
               <input id="newItemTitle" type="text" autocomplete="off" placeholder="Optional title" aria-label="New item title">
+              <select id="newItemStatus" aria-label="New item status">
+                <option value="">Auto</option>
+                <option value="draft">Draft</option>
+                <option value="active">Active</option>
+                <option value="blocked">Blocked</option>
+                <option value="at-risk">At-risk</option>
+                <option value="paused">Paused</option>
+                <option value="open">Open</option>
+              </select>
+              <input id="newItemOwner" type="text" autocomplete="off" placeholder="Owner (optional)" aria-label="New item owner">
+              <textarea id="newItemDescription" rows="2" placeholder="Description (optional)" aria-label="New item description"></textarea>
               <button class="primaryAction" type="submit">Add item</button>
             </form>
 

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -2518,3 +2518,57 @@ button.dangerAction:hover {
     grid-template-columns: 1fr;
   }
 }
+
+/* --- Badge styles (commits A) --- */
+.badge.horizon-now { background: #d1fae5; color: #065f46; }
+.badge.horizon-next { background: #dbeafe; color: #1e40af; }
+.badge.horizon-later { background: #f3f4f6; color: #374151; }
+.badge.horizon-quarter { background: #fef3c7; color: #92400e; }
+.badge.horizon-year { background: #ede9fe; color: #5b21b6; }
+.badge.horizon-someday { background: #f3f4f6; color: #6b7280; }
+.badge.priority-critical { background: #fee2e2; color: #991b1b; }
+.badge.priority-high { background: #fef3c7; color: #92400e; }
+.badge.priority-medium { background: #ede9fe; color: #5b21b6; }
+.badge.priority-low { background: #f3f4f6; color: #374151; }
+
+/* --- Commit C: key hints --- */
+.keyHints { font-size: 10px; color: var(--muted); padding: 2px 8px; }
+
+/* --- Commit E: bulk import --- */
+.bulkImport { margin-top: 8px; }
+.bulkImport summary { cursor: pointer; font-size: 12px; color: var(--muted); padding: 4px 0; }
+.bulkImport .quickAddForm { margin-top: 6px; }
+.bulkImport label { grid-column: 1 / -1; font-size: 11px; color: var(--muted); }
+
+/* --- Commit F: kanban view --- */
+.kanbanBoard { display: flex; gap: 12px; padding: 12px; overflow-x: auto; min-height: 200px; }
+.kanbanLane { min-width: 200px; max-width: 260px; flex: 0 0 220px; background: var(--surface-alt, #f9f9f9); border-radius: 6px; padding: 8px; }
+.kanbanLaneHead { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; font-size: 12px; font-weight: 600; }
+.kanbanCount { background: var(--line-soft); border-radius: 10px; padding: 1px 6px; font-size: 10px; }
+.kanbanCards { display: flex; flex-direction: column; gap: 6px; }
+.kanbanCard { background: var(--surface); border: 1px solid var(--line-soft); border-radius: 4px; padding: 8px; cursor: pointer; }
+.kanbanCard:hover { border-color: var(--accent); }
+.kanbanCard.selected { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-faint, rgba(0,0,0,.08)); }
+.kanbanCardKind { font-size: 9px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin-bottom: 2px; }
+.kanbanCardTitle { font-size: 12px; line-height: 1.4; }
+.kanbanCardOwner { font-size: 10px; color: var(--muted); margin-top: 4px; }
+
+/* --- Commit H: empty state --- */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 40px 20px;
+  color: var(--muted);
+  text-align: center;
+}
+.emptyState p { font-size: 13px; margin: 0; }
+
+/* --- Commit I: inspector dates --- */
+.inspectorDates { font-size: 10px; color: var(--muted); }
+
+/* --- Commit J: archived nodes --- */
+.archivedNode { display: flex; justify-content: space-between; align-items: center; padding: 4px 6px; font-size: 12px; border-bottom: 1px solid var(--line-soft); }
+.archivedNode span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -2354,6 +2354,71 @@ tr:last-child td {
   font-size: 11px;
 }
 
+.inspectorBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 3px;
+}
+
+.inspectorDescription {
+  padding: 6px 0;
+  border-top: 1px solid var(--line-soft);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.inspectorEditForm {
+  display: grid;
+  gap: 7px;
+  padding: 8px 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.inspectorEditForm label {
+  display: grid;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.inspectorEditForm input,
+.inspectorEditForm select,
+.inspectorEditForm textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: #ffffff;
+  color: var(--ink);
+  padding: 5px 7px;
+  font: inherit;
+}
+
+.inspectorEditForm textarea {
+  resize: vertical;
+  min-height: 52px;
+}
+
+.inspectorFormActions {
+  display: flex;
+  gap: 6px;
+}
+
+button.dangerAction {
+  border-color: #fca5a5;
+  color: var(--red, #dc2626);
+  background: #fff5f5;
+}
+
+button.dangerAction:hover {
+  border-color: var(--red, #dc2626);
+  background: #fee2e2;
+}
+
 @media (max-width: 920px) {
   .shell {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #704 (Phase 1)

Builds on top of the stateful UX roadmap (merged in #705). Adds an editable strategy planning layer on top of the existing GitHub dependency graph.

## Changes

### Backend (`internal/core/store.go`)
- `CreateStrategyNode()` — creates local planning nodes with extended kinds (strategy, initiative, bet, project, workstream, risk, decision, question, metric, task, note) and strategy statuses (draft, active, blocked, at-risk, paused, done, rejected)
- `UpdateNodeFields()` — patches title, status, owner, and description on any node
- `RemoveNodeFromBoard()` — removes a node from a board; auto-deletes local-only nodes with no other board references and their scoped edges
- `DeleteEdge()` — deletes a link by edge ID

### Backend (`internal/backend/server.go`)
- `handleBoardItems` rewritten as `switch r.Method` — POST (create), PATCH (update fields), DELETE (remove from board)
- `handleBoardLinks` extended with DELETE (delete edge by ID)
- POST routes strategy kinds through `CreateStrategyNode` (not `AddTaskToBoard`)

### Frontend (`live/app/index.html`, `app.js`, `style.css`)
- **Add Item form** extended with Strategy optgroup (9 kinds) + Local optgroup, plus status, owner, and description fields
- **Item inspector** shows kind+state badges and description; local nodes get an inline edit form (title, status, owner, description) via PATCH, and a "Remove" danger button via DELETE
- **Edge inspector** gets a "Delete link" danger button via DELETE
- `isLocal()` recognises all strategy-kind node ID prefixes
- `lifecycleBadge()` renders active / blocked / at-risk / paused / rejected states
- `isClosed()` includes rejected as a terminal state

## Test plan
- [ ] Create a strategy node (kind=initiative, status=draft) in Actions tab → appears on graph
- [ ] Click node → inspector shows kind badge, state badge, description
- [ ] Click Edit → inline form pre-fills; save → node title/status updates
- [ ] Click Remove → confirm → node disappears from board and graph
- [ ] Add a link between two nodes → click edge inspector → Delete link → edge disappears
- [ ] `go build ./...` passes, `node --check live/app/app.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)