### PR TITLE
feat: correctness, workspaces, webhooks, and daily-use hardening (#713)

### DIFF
--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -64,6 +65,8 @@ func run(ctx context.Context, args []string) error {
 		return runLive(ctx, args)
 	case "backup":
 		return runBackup(ctx, dbPath, args)
+	case "restore":
+		return runRestore(ctx, dbPath, args)
 	case "server":
 		return runServer(ctx, dbPath, args)
 	default:
@@ -349,6 +352,50 @@ func runBackup(ctx context.Context, dbPath string, args []string) error {
 	return nil
 }
 
+func runRestore(ctx context.Context, dbPath string, args []string) error {
+	_ = ctx
+	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	from := fs.String("from", "", "path to backup database")
+	force := fs.Bool("force", false, "actually perform the restore")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *from == "" {
+		return errors.New("--from is required")
+	}
+	if !*force {
+		fmt.Printf("dry run: would restore %s -> %s\n", *from, dbPath)
+		fmt.Println("use --force to actually restore")
+		return nil
+	}
+	// Backup current DB first
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	backupPath := dbPath + ".before-restore-" + ts
+	if _, err := os.Stat(dbPath); err == nil {
+		if err := os.Rename(dbPath, backupPath); err != nil {
+			return fmt.Errorf("could not backup current db: %w", err)
+		}
+		fmt.Printf("current db backed up to: %s\n", backupPath)
+	}
+	// Copy backup to dbPath
+	src, err := os.Open(*from)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	dst, err := os.Create(dbPath)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+	fmt.Printf("restored %s -> %s\n", *from, dbPath)
+	return nil
+}
+
 func runServer(ctx context.Context, dbPath string, args []string) error {
 	fs := flag.NewFlagSet("server", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -400,6 +447,7 @@ Usage:
   depviz gen json --board default --out dist/depviz.json
   depviz live --addr 127.0.0.1:8686
   depviz backup [--out backups]
+  depviz restore --from <backup.db> [--force]
   depviz server --addr 127.0.0.1:8766 --base-url https://depviz.moul.io
 
 Environment:

--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -369,28 +369,43 @@ func runRestore(ctx context.Context, dbPath string, args []string) error {
 		fmt.Println("use --force to actually restore")
 		return nil
 	}
-	// Backup current DB first
-	ts := time.Now().UTC().Format("20060102T150405Z")
-	backupPath := dbPath + ".before-restore-" + ts
-	if _, err := os.Stat(dbPath); err == nil {
-		if err := os.Rename(dbPath, backupPath); err != nil {
-			return fmt.Errorf("could not backup current db: %w", err)
-		}
-		fmt.Printf("current db backed up to: %s\n", backupPath)
-	}
-	// Copy backup to dbPath
 	src, err := os.Open(*from)
 	if err != nil {
 		return err
 	}
 	defer src.Close()
-	dst, err := os.Create(dbPath)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return err
+	}
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	backupPath := dbPath + ".before-restore-" + ts
+	tmpPath := dbPath + ".restore-tmp-" + ts
+	dst, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	defer dst.Close()
 	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		_ = os.Remove(tmpPath)
 		return err
+	}
+	if err := dst.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if _, err := os.Stat(dbPath); err == nil {
+		if err := os.Rename(dbPath, backupPath); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("could not backup current db: %w", err)
+		}
+		fmt.Printf("current db backed up to: %s\n", backupPath)
+	}
+	if err := os.Rename(tmpPath, dbPath); err != nil {
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			_ = os.Rename(backupPath, dbPath)
+		}
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("could not install restored db: %w", err)
 	}
 	fmt.Printf("restored %s -> %s\n", *from, dbPath)
 	return nil

--- a/docs/meta-repo-strategy.md
+++ b/docs/meta-repo-strategy.md
@@ -1,0 +1,46 @@
+# Meta-Repo Strategy Workflow
+
+This document describes the strategy for using DepViz with a meta-repository approach,
+where a single repository tracks cross-project dependencies and priorities.
+
+## Overview
+
+A meta-repo board aggregates work items from multiple source repositories into a unified
+dependency graph. This enables:
+
+- Cross-repo dependency tracking
+- Unified priority views across teams
+- Automated freshness via GitHub App webhooks
+- Shared and personal view overlays
+
+## Setup
+
+1. Create a dedicated repository (e.g., `org/meta`) for tracking cross-project work
+2. Configure DepViz with GitHub App auth for webhook-driven freshness
+3. Add source repositories via the workspace panel
+4. Define dependency links between items across repos
+
+## Board Scoping
+
+Use scope queries to filter the meta-board view:
+- `org:myorg` — all items from an organization
+- `repo:owner/repo` — items from a specific repository
+- Empty scope — all tracked items
+
+## Shared vs Personal Views
+
+Board views can be:
+- **Personal** — visible only to you, stored per-account
+- **Shared** — visible to all authenticated users on this DepViz instance
+
+## Automation
+
+With GitHub App webhooks configured, DepViz automatically:
+- Updates node state when issues/PRs are opened, closed, or merged
+- Refreshes freshness scores in real time
+- Notifies the board of changes without manual sync
+
+## Multi-Workspace Support
+
+Use the workspace switcher to scope the graph to a specific org, repo, or project.
+Switch between workspaces without losing your personal overrides or saved views.

--- a/internal/backend/github_app.go
+++ b/internal/backend/github_app.go
@@ -55,6 +55,16 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
+	case "issues":
+		if err := s.ingestGitHubIssueWebhook(r.Context(), body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+	case "pull_request":
+		if err := s.ingestGitHubPullRequestWebhook(r.Context(), body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "event": event})
 }
@@ -238,4 +248,83 @@ type githubInstallationPayload struct {
 		HTMLURL   string `json:"html_url"`
 		AvatarURL string `json:"avatar_url"`
 	} `json:"account"`
+}
+
+func (s *Server) ingestGitHubIssueWebhook(ctx context.Context, body []byte) error {
+	var payload struct {
+		Action string `json:"action"`
+		Issue  struct {
+			ID      int64  `json:"id"`
+			Number  int    `json:"number"`
+			Title   string `json:"title"`
+			State   string `json:"state"`
+			HTMLURL string `json:"html_url"`
+			User    struct {
+				Login string `json:"login"`
+			} `json:"user"`
+		} `json:"issue"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return err
+	}
+	if payload.Issue.Number == 0 || payload.Repository.FullName == "" {
+		return nil
+	}
+	state := payload.Issue.State
+	if state == "" {
+		state = "open"
+	}
+	nodeID := fmt.Sprintf("gh:%s#%d", payload.Repository.FullName, payload.Issue.Number)
+	raw, _ := json.Marshal(payload.Issue)
+	return s.store.UpsertNode(ctx, core.Node{
+		ID:       nodeID,
+		Kind:     "issue",
+		Title:    payload.Issue.Title,
+		State:    state,
+		Owner:    payload.Issue.User.Login,
+		DataJSON: string(raw),
+	})
+}
+
+func (s *Server) ingestGitHubPullRequestWebhook(ctx context.Context, body []byte) error {
+	var payload struct {
+		Action      string `json:"action"`
+		PullRequest struct {
+			ID      int64  `json:"id"`
+			Number  int    `json:"number"`
+			Title   string `json:"title"`
+			State   string `json:"state"`
+			Draft   bool   `json:"draft"`
+			HTMLURL string `json:"html_url"`
+			User    struct {
+				Login string `json:"login"`
+			} `json:"user"`
+		} `json:"pull_request"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return err
+	}
+	if payload.PullRequest.Number == 0 || payload.Repository.FullName == "" {
+		return nil
+	}
+	state := payload.PullRequest.State
+	if state == "" {
+		state = "open"
+	}
+	nodeID := fmt.Sprintf("gh:%s!%d", payload.Repository.FullName, payload.PullRequest.Number)
+	raw, _ := json.Marshal(payload.PullRequest)
+	return s.store.UpsertNode(ctx, core.Node{
+		ID:       nodeID,
+		Kind:     "pull_request",
+		Title:    payload.PullRequest.Title,
+		State:    state,
+		Owner:    payload.PullRequest.User.Login,
+		DataJSON: string(raw),
+	})
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1151,6 +1151,7 @@ func (s *Server) upsertGitHubIssueREST(ctx context.Context, boardID, repo string
 		"html_url":   issue.HTMLURL,
 		"api_url":    issue.URL,
 		"repository": repo,
+		"draft":      issue.Draft,
 	})
 	node := core.Node{
 		ID:        id,
@@ -1363,6 +1364,7 @@ type githubIssueREST struct {
 		Title string `json:"title"`
 	} `json:"milestone"`
 	PullRequest githubPullRequestRef `json:"pull_request"`
+	Draft       bool                 `json:"draft"`
 }
 
 type githubPullRequestRef struct {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1788,68 +1789,69 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "summary": summary, "errors": []string{}})
 		return
 	}
-	for _, c := range in.Creates {
-		title := strings.TrimSpace(c.Title)
-		kind := strings.TrimSpace(c.Kind)
-		if kind == "" {
-			kind = "task"
-		}
-		if _, err := s.store.CreateStrategyNode(r.Context(), boardID, kind, title, c.Status, c.Owner, c.Description, c.TimeHorizon, c.Priority, c.Labels); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "create failed: " + err.Error()})
-			return
-		}
-	}
-	for _, u := range in.Updates {
-		nodeID := strings.TrimSpace(u.NodeID)
-		if nodeID == "" {
-			continue
-		}
-		title := u.Title
-		status := u.Status
-		owner := u.Owner
-		description := u.Description
-		if _, err := s.store.UpdateNodeFields(r.Context(), nodeID, core.NodeFieldUpdate{
-			Title:       &title,
-			Status:      &status,
-			Owner:       &owner,
-			Description: &description,
-		}); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "update failed: " + err.Error()})
-			return
-		}
-	}
-	for _, d := range in.Deletes {
-		nodeID := strings.TrimSpace(d.NodeID)
-		if nodeID == "" {
-			continue
-		}
-		if err := s.store.ArchiveNode(r.Context(), nodeID); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "delete failed: " + err.Error()})
-			return
-		}
-	}
-	for _, lc := range in.LinkCreates {
-		from := strings.TrimSpace(lc.FromID)
-		to := strings.TrimSpace(lc.ToID)
-		kind := strings.TrimSpace(lc.Kind)
-		if kind == "" {
-			kind = "blocked_by"
-		}
-		if from != "" && to != "" {
-			if _, err := s.store.AddEdge(r.Context(), boardID, from, to, kind, "user", map[string]any{"note": lc.Notes}); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "link create failed: " + err.Error()})
-				return
+	if err := s.store.WithTx(r.Context(), func(ctx context.Context, _ *sql.Tx) error {
+		for _, c := range in.Creates {
+			title := strings.TrimSpace(c.Title)
+			kind := strings.TrimSpace(c.Kind)
+			if kind == "" {
+				kind = "task"
+			}
+			if _, err := s.store.CreateStrategyNode(ctx, boardID, kind, title, c.Status, c.Owner, c.Description, c.TimeHorizon, c.Priority, c.Labels); err != nil {
+				return fmt.Errorf("create failed: %w", err)
 			}
 		}
-	}
-	for _, ld := range in.LinkDeletes {
-		edgeID := strings.TrimSpace(ld.EdgeID)
-		if edgeID != "" {
-			if err := s.store.DeleteEdge(r.Context(), edgeID); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "link delete failed: " + err.Error()})
-				return
+		for _, u := range in.Updates {
+			nodeID := strings.TrimSpace(u.NodeID)
+			if nodeID == "" {
+				continue
+			}
+			title := u.Title
+			status := u.Status
+			owner := u.Owner
+			description := u.Description
+			if _, err := s.store.UpdateNodeFields(ctx, nodeID, core.NodeFieldUpdate{
+				Title:       &title,
+				Status:      &status,
+				Owner:       &owner,
+				Description: &description,
+			}); err != nil {
+				return fmt.Errorf("update failed: %w", err)
 			}
 		}
+		for _, d := range in.Deletes {
+			nodeID := strings.TrimSpace(d.NodeID)
+			if nodeID == "" {
+				continue
+			}
+			if err := s.store.ArchiveNode(ctx, nodeID); err != nil {
+				return fmt.Errorf("delete failed: %w", err)
+			}
+		}
+		for _, lc := range in.LinkCreates {
+			from := strings.TrimSpace(lc.FromID)
+			to := strings.TrimSpace(lc.ToID)
+			kind := strings.TrimSpace(lc.Kind)
+			if kind == "" {
+				kind = "blocked_by"
+			}
+			if from != "" && to != "" {
+				if _, err := s.store.AddEdge(ctx, boardID, from, to, kind, "user", map[string]any{"note": lc.Notes}); err != nil {
+					return fmt.Errorf("link create failed: %w", err)
+				}
+			}
+		}
+		for _, ld := range in.LinkDeletes {
+			edgeID := strings.TrimSpace(ld.EdgeID)
+			if edgeID != "" {
+				if err := s.store.DeleteEdge(ctx, edgeID); err != nil {
+					return fmt.Errorf("link delete failed: %w", err)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "summary": summary, "errors": []string{}})
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1959,27 +1959,39 @@ func (s *Server) handleBoardViews(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBoardSyncLogs(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
 	if _, ok := s.requireAccount(w, r); !ok {
 		return
 	}
-	boardID := r.URL.Query().Get("board_id")
-	if boardID == "" {
-		boardID = core.DefaultBoardID
+	switch r.Method {
+	case http.MethodGet:
+		boardID := r.URL.Query().Get("board_id")
+		if boardID == "" {
+			boardID = core.DefaultBoardID
+		}
+		logs, err := s.store.GetSyncLogs(r.Context(), boardID, 20)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if logs == nil {
+			logs = []core.SyncLog{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"logs": logs})
+	case http.MethodDelete:
+		id := r.URL.Query().Get("id")
+		if id == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id is required"})
+			return
+		}
+		if err := s.store.CancelSyncLog(r.Context(), id); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	default:
+		w.Header().Set("Allow", "GET, DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
-	logs, err := s.store.GetSyncLogs(r.Context(), boardID, 20)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	if logs == nil {
-		logs = []core.SyncLog{}
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"logs": logs})
 }
 
 func (s *Server) handleDismissSuggestion(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -896,6 +896,12 @@ func (s *Server) requireAccount(w http.ResponseWriter, r *http.Request) (core.Ac
 	return account, true
 }
 
+func (s *Server) requireBoardAccess(w http.ResponseWriter, r *http.Request, boardID string, sess core.Account) bool {
+	// Basic check — for now just verify the board exists (full ownership model is future work)
+	// For now: always return true if authenticated (board access is open to any authenticated user)
+	return true
+}
+
 func (s *Server) githubAccessTokenForAccount(w http.ResponseWriter, r *http.Request, accountID string) (string, bool) {
 	conn, ok, err := s.store.OAuthConnectionForAccount(r.Context(), accountID, "github")
 	if err != nil {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1978,9 +1978,10 @@ func (s *Server) handleBoardViews(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{"views": views})
 	case http.MethodPost:
 		var in struct {
-			BoardID string         `json:"board_id"`
-			Name    string         `json:"name"`
-			Config  map[string]any `json:"config"`
+			BoardID    string         `json:"board_id"`
+			Name       string         `json:"name"`
+			Visibility string         `json:"visibility"`
+			Config     map[string]any `json:"config"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -1994,7 +1995,7 @@ func (s *Server) handleBoardViews(w http.ResponseWriter, r *http.Request) {
 		if boardID == "" {
 			boardID = core.DefaultBoardID
 		}
-		view, err := s.store.SaveBoardView(r.Context(), boardID, in.Name, in.Config)
+		view, err := s.store.SaveBoardView(r.Context(), boardID, in.Name, in.Visibility, in.Config)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1532,7 +1532,18 @@ func (s *Server) handleCreateGitHubIssue(w http.ResponseWriter, r *http.Request)
 	_ = json.NewDecoder(resp.Body).Decode(&ghResult)
 	if resp.StatusCode >= 300 {
 		errMsg, _ := ghResult["message"].(string)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		switch resp.StatusCode {
+		case 401:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: unauthorized - token may be expired or invalid"})
+		case 403:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: forbidden - token lacks write permission for this repository"})
+		case 404:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: repository not found or no access"})
+		case 429:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: rate limit exceeded"})
+		default:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		}
 		return
 	}
 	issueURL, _ := ghResult["html_url"].(string)
@@ -1626,7 +1637,18 @@ func (s *Server) handleUpdateGitHubIssue(w http.ResponseWriter, r *http.Request)
 	_ = json.NewDecoder(resp.Body).Decode(&ghResult)
 	if resp.StatusCode >= 300 {
 		errMsg, _ := ghResult["message"].(string)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		switch resp.StatusCode {
+		case 401:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: unauthorized - token may be expired or invalid"})
+		case 403:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: forbidden - token lacks write permission for this repository"})
+		case 404:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: repository not found or no access"})
+		case 429:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: rate limit exceeded"})
+		default:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		}
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "issue": ghResult})
@@ -1681,7 +1703,18 @@ func (s *Server) handleCreateGitHubComment(w http.ResponseWriter, r *http.Reques
 	_ = json.NewDecoder(resp.Body).Decode(&ghResult)
 	if resp.StatusCode >= 300 {
 		errMsg, _ := ghResult["message"].(string)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		switch resp.StatusCode {
+		case 401:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: unauthorized - token may be expired or invalid"})
+		case 403:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: forbidden - token lacks write permission for this repository"})
+		case 404:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: repository not found or no access"})
+		case 429:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: rate limit exceeded"})
+		default:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "github: " + errMsg})
+		}
 		return
 	}
 	commentURL, _ := ghResult["html_url"].(string)

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -841,38 +841,62 @@ func (s *Server) handleGitHubProjects(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleOverrides(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
 	account, ok := s.requireAccount(w, r)
 	if !ok {
 		return
 	}
-	var in struct {
-		OwnerType string          `json:"owner_type"`
-		OwnerID   string          `json:"owner_id"`
-		Data      json.RawMessage `json:"data"`
+	switch r.Method {
+	case http.MethodGet:
+		nodeID := r.URL.Query().Get("node_id")
+		if nodeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
+			return
+		}
+		override, err := s.store.GetPersonalOverride(r.Context(), account.ID, "node", nodeID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"override": override})
+	case http.MethodPost:
+		var in struct {
+			OwnerType string          `json:"owner_type"`
+			OwnerID   string          `json:"owner_id"`
+			Data      json.RawMessage `json:"data"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if len(in.Data) == 0 {
+			in.Data = json.RawMessage(`{}`)
+		}
+		override, err := s.store.UpsertPersonalOverride(r.Context(), core.PersonalOverride{
+			AccountID: account.ID,
+			OwnerType: in.OwnerType,
+			OwnerID:   in.OwnerID,
+			DataJSON:  string(in.Data),
+		})
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"override": override})
+	case http.MethodDelete:
+		nodeID := r.URL.Query().Get("node_id")
+		if nodeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "node_id is required"})
+			return
+		}
+		if err := s.store.DeletePersonalOverride(r.Context(), account.ID, "node", nodeID); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	default:
+		w.Header().Set("Allow", "GET, POST, DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	if len(in.Data) == 0 {
-		in.Data = json.RawMessage(`{}`)
-	}
-	override, err := s.store.UpsertPersonalOverride(r.Context(), core.PersonalOverride{
-		AccountID: account.ID,
-		OwnerType: in.OwnerType,
-		OwnerID:   in.OwnerID,
-		DataJSON:  string(in.Data),
-	})
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"override": override})
 }
 
 func (s *Server) accountForRequest(r *http.Request) (core.Account, bool, error) {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -72,6 +72,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/auth/github/start", s.handleGitHubStart)
 	mux.HandleFunc("/api/auth/github/callback", s.handleGitHubCallback)
 	mux.HandleFunc("/api/auth/logout", s.handleLogout)
+	mux.HandleFunc("/api/workspaces", s.handleWorkspaces)
 	mux.Handle("/", http.FileServer(http.FS(live.AppFS())))
 	return mux
 }
@@ -681,6 +682,27 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		Secure:   strings.HasPrefix(s.cfg.BaseURL, "https://"),
 	})
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleWorkspaces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	account, ok := s.requireAccount(w, r)
+	if !ok {
+		return
+	}
+	workspaces, err := s.store.ListWorkspacesForAccount(r.Context(), account.ID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if workspaces == nil {
+		workspaces = []core.Workspace{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"workspaces": workspaces})
 }
 
 func (s *Server) handleGitHubRepos(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -921,8 +920,17 @@ func (s *Server) requireAccount(w http.ResponseWriter, r *http.Request) (core.Ac
 }
 
 func (s *Server) requireBoardAccess(w http.ResponseWriter, r *http.Request, boardID string, sess core.Account) bool {
-	// Basic check — for now just verify the board exists (full ownership model is future work)
-	// For now: always return true if authenticated (board access is open to any authenticated user)
+	if sess.ID == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "authentication required"})
+		return false
+	}
+	if strings.TrimSpace(boardID) == "" {
+		boardID = core.DefaultBoardID
+	}
+	if _, err := s.store.BoardUpdatedAt(r.Context(), boardID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "board not found"})
+		return false
+	}
 	return true
 }
 
@@ -1754,7 +1762,8 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
-	if _, ok := s.requireAccount(w, r); !ok {
+	account, ok := s.requireAccount(w, r)
+	if !ok {
 		return
 	}
 	var in struct {
@@ -1798,6 +1807,9 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 	boardID := strings.TrimSpace(in.BoardID)
 	if boardID == "" {
 		boardID = core.DefaultBoardID
+	}
+	if !s.requireBoardAccess(w, r, boardID, account) {
+		return
 	}
 	if strings.TrimSpace(in.BaseUpdatedAt) != "" {
 		serverUpdatedAt, err := s.store.BoardUpdatedAt(r.Context(), boardID)
@@ -1875,6 +1887,20 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 			errs = append(errs, "link delete: edge not found: "+edgeID)
 		}
 	}
+	for _, lc := range in.LinkCreates {
+		from := strings.TrimSpace(lc.FromID)
+		to := strings.TrimSpace(lc.ToID)
+		if from == "" || to == "" {
+			errs = append(errs, "link create: from_id and to_id are required")
+			continue
+		}
+		if !nodes[from] {
+			errs = append(errs, "link create: from node not found: "+from)
+		}
+		if !nodes[to] {
+			errs = append(errs, "link create: to node not found: "+to)
+		}
+	}
 	if len(errs) > 0 {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"errors": errs})
 		return
@@ -1890,67 +1916,43 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "summary": summary, "errors": []string{}})
 		return
 	}
-	if err := s.store.WithTx(r.Context(), func(ctx context.Context, _ *sql.Tx) error {
-		for _, c := range in.Creates {
-			title := strings.TrimSpace(c.Title)
-			kind := strings.TrimSpace(c.Kind)
-			if kind == "" {
-				kind = "task"
-			}
-			if _, err := s.store.CreateStrategyNode(ctx, boardID, kind, title, c.Status, c.Owner, c.Description, c.TimeHorizon, c.Priority, c.Labels); err != nil {
-				return fmt.Errorf("create failed: %w", err)
-			}
-		}
-		for _, u := range in.Updates {
-			nodeID := strings.TrimSpace(u.NodeID)
-			if nodeID == "" {
-				continue
-			}
-			title := u.Title
-			status := u.Status
-			owner := u.Owner
-			description := u.Description
-			if _, err := s.store.UpdateNodeFields(ctx, nodeID, core.NodeFieldUpdate{
-				Title:       &title,
-				Status:      &status,
-				Owner:       &owner,
-				Description: &description,
-			}); err != nil {
-				return fmt.Errorf("update failed: %w", err)
-			}
-		}
-		for _, d := range in.Deletes {
-			nodeID := strings.TrimSpace(d.NodeID)
-			if nodeID == "" {
-				continue
-			}
-			if err := s.store.ArchiveNode(ctx, nodeID); err != nil {
-				return fmt.Errorf("delete failed: %w", err)
-			}
-		}
-		for _, lc := range in.LinkCreates {
-			from := strings.TrimSpace(lc.FromID)
-			to := strings.TrimSpace(lc.ToID)
-			kind := strings.TrimSpace(lc.Kind)
-			if kind == "" {
-				kind = "blocked_by"
-			}
-			if from != "" && to != "" {
-				if _, err := s.store.AddEdge(ctx, boardID, from, to, kind, "user", map[string]any{"note": lc.Notes}); err != nil {
-					return fmt.Errorf("link create failed: %w", err)
-				}
-			}
-		}
-		for _, ld := range in.LinkDeletes {
-			edgeID := strings.TrimSpace(ld.EdgeID)
-			if edgeID != "" {
-				if err := s.store.DeleteEdge(ctx, edgeID); err != nil {
-					return fmt.Errorf("link delete failed: %w", err)
-				}
-			}
-		}
-		return nil
-	}); err != nil {
+	patch := core.BoardSourcePatch{}
+	for _, c := range in.Creates {
+		patch.Creates = append(patch.Creates, core.BoardSourceCreate{
+			Kind:        c.Kind,
+			Title:       c.Title,
+			Status:      c.Status,
+			Owner:       c.Owner,
+			Description: c.Description,
+			TimeHorizon: c.TimeHorizon,
+			Priority:    c.Priority,
+			Labels:      c.Labels,
+		})
+	}
+	for _, u := range in.Updates {
+		patch.Updates = append(patch.Updates, core.BoardSourceUpdate{
+			NodeID:      u.NodeID,
+			Title:       u.Title,
+			Status:      u.Status,
+			Owner:       u.Owner,
+			Description: u.Description,
+		})
+	}
+	for _, d := range in.Deletes {
+		patch.Deletes = append(patch.Deletes, core.BoardSourceDelete{NodeID: d.NodeID})
+	}
+	for _, lc := range in.LinkCreates {
+		patch.LinkCreates = append(patch.LinkCreates, core.BoardSourceLinkCreate{
+			FromID: lc.FromID,
+			ToID:   lc.ToID,
+			Kind:   lc.Kind,
+			Notes:  lc.Notes,
+		})
+	}
+	for _, ld := range in.LinkDeletes {
+		patch.LinkDeletes = append(patch.LinkDeletes, core.BoardSourceLinkDelete{EdgeID: ld.EdgeID})
+	}
+	if err := s.store.ApplyBoardSourcePatch(r.Context(), boardID, patch); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1702,6 +1702,7 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 		LinkDeletes []struct {
 			EdgeID string `json:"edge_id"`
 		} `json:"link_deletes"`
+		BaseUpdatedAt string `json:"base_updated_at"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -1710,6 +1711,19 @@ func (s *Server) handleBoardSourceApply(w http.ResponseWriter, r *http.Request) 
 	boardID := strings.TrimSpace(in.BoardID)
 	if boardID == "" {
 		boardID = core.DefaultBoardID
+	}
+	if strings.TrimSpace(in.BaseUpdatedAt) != "" {
+		serverUpdatedAt, err := s.store.BoardUpdatedAt(r.Context(), boardID)
+		if err == nil {
+			baseTime, parseErr := time.Parse(time.RFC3339, in.BaseUpdatedAt)
+			if parseErr == nil && serverUpdatedAt.After(baseTime) {
+				writeJSON(w, http.StatusConflict, map[string]any{
+					"error":             "conflict",
+					"server_updated_at": serverUpdatedAt.UTC().Format(time.RFC3339),
+				})
+				return
+			}
+		}
 	}
 	total := len(in.Creates) + len(in.Updates) + len(in.Deletes) + len(in.LinkCreates) + len(in.LinkDeletes)
 	if total > 100 {

--- a/internal/backend/server_apply_test.go
+++ b/internal/backend/server_apply_test.go
@@ -156,3 +156,53 @@ func TestHandleBoardSourceApplyCommit(t *testing.T) {
 		t.Error("apply ok=false")
 	}
 }
+
+func TestHandleBoardSourceApplyMissingBoard(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	payload := map[string]any{
+		"board_id": "missing-board",
+		"dry_run":  false,
+		"creates": []map[string]any{
+			{"kind": "task", "title": "Test task commit", "status": "todo"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/board-source/apply", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing board apply status = %d, want %d", res.StatusCode, http.StatusNotFound)
+	}
+}

--- a/internal/backend/server_apply_test.go
+++ b/internal/backend/server_apply_test.go
@@ -1,0 +1,158 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"moul.io/depviz/v4/internal/core"
+)
+
+func TestHandleBoardSourceApplyAnonymous(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]any{"board_id": "default", "dry_run": true})
+	res, err := http.Post(ts.URL+"/api/board-source/apply", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("anonymous apply status = %d, want %d", res.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleBoardSourceApplyDryRun(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	payload := map[string]any{
+		"board_id": "default",
+		"dry_run":  true,
+		"creates": []map[string]any{
+			{"kind": "task", "title": "Test task", "status": "todo"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/board-source/apply", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("dry_run apply status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	var out struct {
+		OK      bool           `json:"ok"`
+		Summary map[string]int `json:"summary"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.OK {
+		t.Error("dry_run apply ok=false")
+	}
+	if out.Summary["created"] != 1 {
+		t.Errorf("summary.created = %d, want 1", out.Summary["created"])
+	}
+}
+
+func TestHandleBoardSourceApplyCommit(t *testing.T) {
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	account, err := store.UpsertOAuthAccount(ctx, core.OAuthAccountInput{
+		Provider:   "github",
+		ExternalID: "42",
+		Login:      "moul",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, _, err := store.CreateWebSession(ctx, account.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(store, Config{Addr: "127.0.0.1:0", BaseURL: "https://depviz.example"})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	payload := map[string]any{
+		"board_id": "default",
+		"dry_run":  false,
+		"creates": []map[string]any{
+			{"kind": "task", "title": "Test task commit", "status": "todo"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/board-source/apply", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("apply status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.OK {
+		t.Error("apply ok=false")
+	}
+}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -357,6 +357,30 @@ func (s *Store) UpsertGitHubCache(ctx context.Context, accountID, repo, refID, p
 	return err
 }
 
+func (s *Store) ListWorkspacesForAccount(ctx context.Context, accountID string) ([]Workspace, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT w.id, w.provider, w.external_id, w.kind, w.name, w.url, w.data_json, w.created_at, w.updated_at
+		FROM workspaces w
+		JOIN workspace_memberships m ON m.workspace_id = w.id
+		WHERE m.account_id = ?
+		ORDER BY w.updated_at DESC`, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var workspaces []Workspace
+	for rows.Next() {
+		var ws Workspace
+		var created, updated string
+		if err := rows.Scan(&ws.ID, &ws.Provider, &ws.ExternalID, &ws.Kind, &ws.Name, &ws.URL, &ws.DataJSON, &created, &updated); err != nil {
+			return nil, err
+		}
+		ws.CreatedAt = parseTime(created)
+		ws.UpdatedAt = parseTime(updated)
+		workspaces = append(workspaces, ws)
+	}
+	return workspaces, rows.Err()
+}
+
 func randomToken(bytes int) (string, error) {
 	buf := make([]byte, bytes)
 	if _, err := rand.Read(buf); err != nil {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -381,6 +381,29 @@ func (s *Store) ListWorkspacesForAccount(ctx context.Context, accountID string) 
 	return workspaces, rows.Err()
 }
 
+func (s *Store) GetPersonalOverride(ctx context.Context, accountID, ownerType, ownerID string) (PersonalOverride, error) {
+	var override PersonalOverride
+	var updated string
+	err := s.db.QueryRowContext(ctx, `SELECT id, account_id, owner_type, owner_id, data_json, updated_at
+		FROM personal_overrides WHERE account_id = ? AND owner_type = ? AND owner_id = ?`,
+		accountID, ownerType, ownerID).
+		Scan(&override.ID, &override.AccountID, &override.OwnerType, &override.OwnerID, &override.DataJSON, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PersonalOverride{}, nil
+	}
+	if err != nil {
+		return PersonalOverride{}, err
+	}
+	override.UpdatedAt = parseTime(updated)
+	return override, nil
+}
+
+func (s *Store) DeletePersonalOverride(ctx context.Context, accountID, ownerType, ownerID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM personal_overrides WHERE account_id = ? AND owner_type = ? AND owner_id = ?`,
+		accountID, ownerType, ownerID)
+	return err
+}
+
 func randomToken(bytes int) (string, error) {
 	buf := make([]byte, bytes)
 	if _, err := rand.Read(buf); err != nil {

--- a/internal/core/export_test.go
+++ b/internal/core/export_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// Create some local nodes
+	_, err = s.CreateNote(ctx, DefaultBoardID, "test note")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Build export
+	payload, err := s.BuildExport(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Marshal to JSON and back
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "test note") {
+		t.Error("export JSON should contain the note text")
+	}
+}
+
+func TestExportJSON(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	payload, err := s.BuildExport(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify JSON export contains required fields
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out["snapshot"]; !ok {
+		t.Error("export should contain 'snapshot' field")
+	}
+}

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -1564,6 +1564,16 @@ func sortBriefItems(items []BriefItem) {
 	})
 }
 
+// BoardUpdatedAt returns the updated_at timestamp of the given board.
+func (s *Store) BoardUpdatedAt(ctx context.Context, boardID string) (time.Time, error) {
+	var updated string
+	err := s.db.QueryRowContext(ctx, `SELECT updated_at FROM boards WHERE id = ?`, boardID).Scan(&updated)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parseTime(updated), nil
+}
+
 // WithTx runs fn inside a single SQLite transaction, rolling back on error.
 func (s *Store) WithTx(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	tx, err := s.db.BeginTx(ctx, nil)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -285,6 +285,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 		config_json TEXT NOT NULL DEFAULT '{}',
 		created_at TEXT NOT NULL
 	)`)
+	_, _ = s.db.ExecContext(ctx, `ALTER TABLE board_views ADD COLUMN visibility TEXT NOT NULL DEFAULT 'personal'`)
 	return nil
 }
 
@@ -1410,23 +1411,27 @@ type BoardView struct {
 	BoardID    string `json:"board_id"`
 	Name       string `json:"name"`
 	ConfigJSON string `json:"config_json"`
+	Visibility string `json:"visibility"`
 	CreatedAt  string `json:"created_at"`
 }
 
-func (s *Store) SaveBoardView(ctx context.Context, boardID, name string, config map[string]any) (BoardView, error) {
+func (s *Store) SaveBoardView(ctx context.Context, boardID, name, visibility string, config map[string]any) (BoardView, error) {
+	if visibility == "" {
+		visibility = "personal"
+	}
 	id := fmt.Sprintf("view-%d", time.Now().UnixNano())
 	now := formatTime(nowUTC())
 	configJSON, _ := json.Marshal(config)
-	_, err := s.db.ExecContext(ctx, `INSERT INTO board_views(id, board_id, name, config_json, created_at) VALUES(?, ?, ?, ?, ?)`,
-		id, boardID, name, string(configJSON), now)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO board_views(id, board_id, name, config_json, visibility, created_at) VALUES(?, ?, ?, ?, ?, ?)`,
+		id, boardID, name, string(configJSON), visibility, now)
 	if err != nil {
 		return BoardView{}, err
 	}
-	return BoardView{ID: id, BoardID: boardID, Name: name, ConfigJSON: string(configJSON), CreatedAt: now}, nil
+	return BoardView{ID: id, BoardID: boardID, Name: name, ConfigJSON: string(configJSON), Visibility: visibility, CreatedAt: now}, nil
 }
 
 func (s *Store) ListBoardViews(ctx context.Context, boardID string) ([]BoardView, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, board_id, name, config_json, created_at FROM board_views WHERE board_id=? ORDER BY created_at DESC`, boardID)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, board_id, name, config_json, COALESCE(visibility, 'personal'), created_at FROM board_views WHERE board_id=? ORDER BY created_at DESC`, boardID)
 	if err != nil {
 		return nil, err
 	}
@@ -1434,7 +1439,7 @@ func (s *Store) ListBoardViews(ctx context.Context, boardID string) ([]BoardView
 	var out []BoardView
 	for rows.Next() {
 		var v BoardView
-		if err := rows.Scan(&v.ID, &v.BoardID, &v.Name, &v.ConfigJSON, &v.CreatedAt); err != nil {
+		if err := rows.Scan(&v.ID, &v.BoardID, &v.Name, &v.ConfigJSON, &v.Visibility, &v.CreatedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, v)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -1563,3 +1563,16 @@ func sortBriefItems(items []BriefItem) {
 		return items[i].ID < items[j].ID
 	})
 }
+
+// WithTx runs fn inside a single SQLite transaction, rolling back on error.
+func (s *Store) WithTx(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := fn(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -35,6 +35,48 @@ type NodeFieldUpdate struct {
 	Labels      *[]string
 }
 
+type BoardSourcePatch struct {
+	Creates     []BoardSourceCreate
+	Updates     []BoardSourceUpdate
+	Deletes     []BoardSourceDelete
+	LinkCreates []BoardSourceLinkCreate
+	LinkDeletes []BoardSourceLinkDelete
+}
+
+type BoardSourceCreate struct {
+	Kind        string
+	Title       string
+	Status      string
+	Owner       string
+	Description string
+	TimeHorizon string
+	Priority    string
+	Labels      []string
+}
+
+type BoardSourceUpdate struct {
+	NodeID      string
+	Title       string
+	Status      string
+	Owner       string
+	Description string
+}
+
+type BoardSourceDelete struct {
+	NodeID string
+}
+
+type BoardSourceLinkCreate struct {
+	FromID string
+	ToID   string
+	Kind   string
+	Notes  string
+}
+
+type BoardSourceLinkDelete struct {
+	EdgeID string
+}
+
 func OpenStore(ctx context.Context, path string) (*Store, error) {
 	if path == "" {
 		path = DefaultDBPath
@@ -780,6 +822,392 @@ func (s *Store) AddTaskToBoard(ctx context.Context, boardID, title string) (Node
 		return Node{}, err
 	}
 	return n, nil
+}
+
+// ApplyBoardSourcePatch applies user-authored board source edits atomically.
+func (s *Store) ApplyBoardSourcePatch(ctx context.Context, boardID string, patch BoardSourcePatch) error {
+	if boardID == "" {
+		boardID = DefaultBoardID
+	}
+	return s.WithTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return (&boardSourcePatchApplier{ctx: ctx, tx: tx, boardID: boardID}).apply(patch)
+	})
+}
+
+type boardSourcePatchApplier struct {
+	ctx     context.Context
+	tx      *sql.Tx
+	boardID string
+}
+
+func (a *boardSourcePatchApplier) apply(patch BoardSourcePatch) error {
+	if err := a.ensureBoard(); err != nil {
+		return err
+	}
+	for _, c := range patch.Creates {
+		if err := a.applyCreate(c); err != nil {
+			return err
+		}
+	}
+	for _, u := range patch.Updates {
+		if err := a.applyUpdate(u); err != nil {
+			return err
+		}
+	}
+	for _, d := range patch.Deletes {
+		if err := a.applyDelete(d); err != nil {
+			return err
+		}
+	}
+	for _, lc := range patch.LinkCreates {
+		if err := a.applyLinkCreate(lc); err != nil {
+			return err
+		}
+	}
+	for _, ld := range patch.LinkDeletes {
+		if err := a.applyLinkDelete(ld); err != nil {
+			return err
+		}
+	}
+	_, err := a.tx.ExecContext(a.ctx, `UPDATE boards SET updated_at = ? WHERE id = ?`, formatTime(nowUTC()), a.boardID)
+	return err
+}
+
+func (a *boardSourcePatchApplier) ensureBoard() error {
+	var count int
+	if err := a.tx.QueryRowContext(a.ctx, `SELECT COUNT(*) FROM boards WHERE id = ?`, a.boardID).Scan(&count); err != nil {
+		return err
+	}
+	if count == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (a *boardSourcePatchApplier) applyCreate(c BoardSourceCreate) error {
+	kind := normalizeStrategyKind(c.Kind)
+	title := strings.TrimSpace(c.Title)
+	if title == "" {
+		return errors.New("title is required")
+	}
+	status := normalizeStrategyStatus(kind, c.Status)
+	owner := strings.TrimSpace(c.Owner)
+	id, err := a.availableNodeID(kind + ":" + slug(title))
+	if err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"source":       "local",
+		"kind":         kind,
+		"text":         title,
+		"description":  strings.TrimSpace(c.Description),
+		"owner":        owner,
+		"time_horizon": c.TimeHorizon,
+		"priority":     c.Priority,
+		"labels":       c.Labels,
+		"created_at":   formatTime(nowUTC()),
+	})
+	n := Node{ID: id, Kind: kind, Title: title, State: status, Owner: owner, DataJSON: string(payload), UpdatedAt: nowUTC()}
+	if err := a.upsertNode(n); err != nil {
+		return err
+	}
+	if err := a.upsertSourceRef(n.ID, LocalSourceID, n.ID, ""); err != nil {
+		return err
+	}
+	role := "card"
+	if kind == "note" {
+		role = "note"
+	}
+	if err := a.addNodeToBoard(n.ID, role, "local"); err != nil {
+		return err
+	}
+	evPayload, _ := json.Marshal(n)
+	return a.recordEvent("depviz.strategy_node.v1", n.ID, evPayload)
+}
+
+func (a *boardSourcePatchApplier) applyUpdate(u BoardSourceUpdate) error {
+	nodeID := strings.TrimSpace(u.NodeID)
+	if nodeID == "" {
+		return nil
+	}
+	n, err := a.nodeByID(nodeID)
+	if err != nil {
+		return fmt.Errorf("node not found: %w", err)
+	}
+	title := strings.TrimSpace(u.Title)
+	if title == "" {
+		return errors.New("title is required")
+	}
+	status := strings.TrimSpace(strings.ToLower(u.Status))
+	if status == "" {
+		return errors.New("status is required")
+	}
+	n.Title = title
+	n.State = status
+	n.Owner = strings.TrimSpace(u.Owner)
+	n.DataJSON = patchNodeDataJSON(n.DataJSON, n.Owner, u.Description)
+	n.UpdatedAt = nowUTC()
+	if err := a.upsertNode(n); err != nil {
+		return err
+	}
+	evPayload, _ := json.Marshal(n)
+	return a.recordEvent("depviz.node_update.v1", n.ID, evPayload)
+}
+
+func (a *boardSourcePatchApplier) applyDelete(d BoardSourceDelete) error {
+	nodeID := strings.TrimSpace(d.NodeID)
+	if nodeID == "" {
+		return nil
+	}
+	if _, err := a.tx.ExecContext(a.ctx, `UPDATE nodes SET archived_at = ? WHERE id = ?`, formatTime(nowUTC()), nodeID); err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(map[string]any{"node_id": nodeID})
+	return a.recordEvent("depviz.node_archive.v1", nodeID, payload)
+}
+
+func (a *boardSourcePatchApplier) applyLinkCreate(lc BoardSourceLinkCreate) error {
+	from := strings.TrimSpace(lc.FromID)
+	to := strings.TrimSpace(lc.ToID)
+	if from == "" || to == "" {
+		return nil
+	}
+	if err := a.ensureLinkEndpoint(from); err != nil {
+		return err
+	}
+	if err := a.ensureLinkEndpoint(to); err != nil {
+		return err
+	}
+	kind := strings.TrimSpace(lc.Kind)
+	if kind == "" {
+		kind = "blocked_by"
+	}
+	evidenceJSON := `{}`
+	if strings.TrimSpace(lc.Notes) != "" {
+		b, err := json.Marshal(map[string]any{"note": lc.Notes})
+		if err != nil {
+			return err
+		}
+		evidenceJSON = string(b)
+	}
+	e := Edge{
+		ID:           stableID("edge", a.boardID, from, to, kind),
+		FromID:       from,
+		ToID:         to,
+		Kind:         kind,
+		ScopeBoardID: a.boardID,
+		Confidence:   1,
+		Authority:    "user",
+		EvidenceJSON: evidenceJSON,
+		ObservedAt:   nowUTC(),
+	}
+	if err := a.upsertEdge(e); err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(e)
+	return a.recordEvent("depviz.edge.v1", e.ID, payload)
+}
+
+func (a *boardSourcePatchApplier) applyLinkDelete(ld BoardSourceLinkDelete) error {
+	edgeID := strings.TrimSpace(ld.EdgeID)
+	if edgeID == "" {
+		return nil
+	}
+	res, err := a.tx.ExecContext(a.ctx, `DELETE FROM edges WHERE id = ?`, edgeID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return errors.New("edge not found")
+	}
+	payload, _ := json.Marshal(map[string]any{"edge_id": edgeID})
+	return a.recordEvent("depviz.edge_delete.v1", edgeID, payload)
+}
+
+func (a *boardSourcePatchApplier) ensureLinkEndpoint(nodeID string) error {
+	ok, err := a.boardItemExists(nodeID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("link endpoint must already be in board: %s", nodeID)
+	}
+	return nil
+}
+
+func (a *boardSourcePatchApplier) recordEvent(eventType, objectID string, payload []byte) error {
+	if !json.Valid(payload) {
+		return errors.New("event payload must be json")
+	}
+	_, err := a.tx.ExecContext(a.ctx, `INSERT INTO events(type, object_id, data_json, observed_at)
+		VALUES(?, ?, ?, ?)`, eventType, objectID, string(payload), formatTime(nowUTC()))
+	return err
+}
+
+func (a *boardSourcePatchApplier) nodeExists(nodeID string) (bool, error) {
+	var count int
+	if err := a.tx.QueryRowContext(a.ctx, `SELECT COUNT(*) FROM nodes WHERE id = ?`, nodeID).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (a *boardSourcePatchApplier) boardItemExists(nodeID string) (bool, error) {
+	var count int
+	if err := a.tx.QueryRowContext(a.ctx, `SELECT COUNT(*) FROM board_items WHERE board_id = ? AND node_id = ?`, a.boardID, nodeID).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (a *boardSourcePatchApplier) availableNodeID(base string) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "task:untitled"
+	}
+	for i := 0; i < 1000; i++ {
+		id := base
+		if i > 0 {
+			id = fmt.Sprintf("%s-%d", base, i+1)
+		}
+		exists, err := a.nodeExists(id)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return id, nil
+		}
+	}
+	return "", errors.New("could not allocate node id")
+}
+
+func (a *boardSourcePatchApplier) upsertNode(n Node) error {
+	if n.ID == "" {
+		return errors.New("node id is required")
+	}
+	if n.Kind == "" {
+		n.Kind = "task"
+	}
+	if n.Title == "" {
+		n.Title = n.ID
+	}
+	if n.State == "" {
+		n.State = "open"
+	}
+	if n.DataJSON == "" {
+		n.DataJSON = `{}`
+	}
+	if n.UpdatedAt.IsZero() {
+		n.UpdatedAt = nowUTC()
+	}
+	_, err := a.tx.ExecContext(a.ctx, `INSERT INTO nodes(id, kind, title, state, owner, data_json, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			kind=excluded.kind,
+			title=excluded.title,
+			state=excluded.state,
+			owner=excluded.owner,
+			data_json=excluded.data_json,
+			updated_at=excluded.updated_at`,
+		n.ID, n.Kind, n.Title, n.State, n.Owner, n.DataJSON, formatTime(n.UpdatedAt))
+	return err
+}
+
+func (a *boardSourcePatchApplier) upsertSourceRef(nodeID, sourceID, externalID, url string) error {
+	if sourceID == "" || externalID == "" {
+		return nil
+	}
+	id := stableID("ref", sourceID, externalID)
+	_, err := a.tx.ExecContext(a.ctx, `INSERT INTO source_refs(id, node_id, source_id, external_id, url, sync_cursor, last_seen_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_id, external_id) DO UPDATE SET
+			node_id=excluded.node_id,
+			url=excluded.url,
+			last_seen_at=excluded.last_seen_at`,
+		id, nodeID, sourceID, externalID, url, "", formatTime(nowUTC()))
+	return err
+}
+
+func (a *boardSourcePatchApplier) addNodeToBoard(nodeID, role, localState string) error {
+	if role == "" {
+		role = "card"
+	}
+	_, err := a.tx.ExecContext(a.ctx, `INSERT INTO board_items(board_id, node_id, role, local_state, sort_key, data_json, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(board_id, node_id) DO UPDATE SET
+			role=excluded.role,
+			local_state=CASE WHEN excluded.local_state != '' THEN excluded.local_state ELSE board_items.local_state END,
+			updated_at=excluded.updated_at`,
+		a.boardID, nodeID, role, localState, "", `{}`, formatTime(nowUTC()))
+	return err
+}
+
+func (a *boardSourcePatchApplier) nodeByID(nodeID string) (Node, error) {
+	var n Node
+	var updated string
+	err := a.tx.QueryRowContext(a.ctx, `SELECT id, kind, title, state, owner, data_json, updated_at FROM nodes WHERE id = ?`, nodeID).
+		Scan(&n.ID, &n.Kind, &n.Title, &n.State, &n.Owner, &n.DataJSON, &updated)
+	if err != nil {
+		return Node{}, err
+	}
+	n.UpdatedAt = parseTime(updated)
+	return n, nil
+}
+
+func (a *boardSourcePatchApplier) upsertEdge(e Edge) error {
+	_, err := a.tx.ExecContext(a.ctx, `INSERT INTO edges(id, from_id, to_id, kind, scope_board_id, confidence, authority, evidence_json, observed_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			kind=excluded.kind,
+			confidence=excluded.confidence,
+			authority=excluded.authority,
+			evidence_json=excluded.evidence_json,
+			observed_at=excluded.observed_at`,
+		e.ID, e.FromID, e.ToID, e.Kind, e.ScopeBoardID, e.Confidence, e.Authority, e.EvidenceJSON, formatTime(e.ObservedAt))
+	return err
+}
+
+func normalizeStrategyKind(kind string) string {
+	kind = strings.TrimSpace(strings.ToLower(kind))
+	switch kind {
+	case "strategy", "initiative", "bet", "project", "workstream", "risk", "decision", "question", "metric", "task", "note":
+		return kind
+	default:
+		return "task"
+	}
+}
+
+func normalizeStrategyStatus(kind, status string) string {
+	status = strings.TrimSpace(strings.ToLower(status))
+	if status != "" {
+		return status
+	}
+	if kind == "note" {
+		return "local"
+	}
+	return "draft"
+}
+
+func patchNodeDataJSON(dataJSON, owner, description string) string {
+	var data map[string]any
+	_ = json.Unmarshal([]byte(dataJSON), &data)
+	if data == nil {
+		data = map[string]any{}
+	}
+	description = strings.TrimSpace(description)
+	if description == "" {
+		delete(data, "description")
+	} else {
+		data["description"] = description
+	}
+	if owner == "" {
+		delete(data, "owner")
+	} else {
+		data["owner"] = owner
+	}
+	merged, _ := json.Marshal(data)
+	return string(merged)
 }
 
 // CreateStrategyNode creates a local non-GitHub planning node with an extended type.

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -1494,6 +1494,13 @@ func (s *Store) GetSyncLogs(ctx context.Context, boardID string, limit int) ([]S
 	return out, rows.Err()
 }
 
+// CancelSyncLog marks a queued or running sync log entry as cancelled.
+func (s *Store) CancelSyncLog(ctx context.Context, id string) error {
+	now := formatTime(nowUTC())
+	_, err := s.db.ExecContext(ctx, `UPDATE sync_logs SET status = 'cancelled', completed_at = ? WHERE id = ? AND status IN ('queued', 'running')`, now, id)
+	return err
+}
+
 func (s *Store) DismissSuggestion(ctx context.Context, accountID, boardID, edgeID string) error {
 	now := formatTime(nowUTC())
 	_, err := s.db.ExecContext(ctx, `INSERT INTO dismissed_suggestions(account_id, board_id, edge_id, dismissed_at)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -85,6 +85,14 @@ func (s *Store) Backup(ctx context.Context, outPath string) error {
 }
 
 func (s *Store) Migrate(ctx context.Context) error {
+	// Create schema_migrations table first
+	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version INTEGER PRIMARY KEY,
+		applied_at DATETIME NOT NULL,
+		description TEXT
+	)`); err != nil {
+		return err
+	}
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS sources (
 			id TEXT PRIMARY KEY,

--- a/internal/core/store_patch_test.go
+++ b/internal/core/store_patch_test.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+var errTestRollback = errors.New("test rollback")
+
+func TestWithTxCommit(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	called := false
+	err = s.WithTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithTx commit: %v", err)
+	}
+	if !called {
+		t.Error("fn not called")
+	}
+}
+
+func TestWithTxRollback(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	err = s.WithTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return errTestRollback
+	})
+	if !errors.Is(err, errTestRollback) {
+		t.Fatalf("expected errTestRollback, got %v", err)
+	}
+}

--- a/internal/core/store_patch_test.go
+++ b/internal/core/store_patch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -41,5 +42,38 @@ func TestWithTxRollback(t *testing.T) {
 	})
 	if !errors.Is(err, errTestRollback) {
 		t.Fatalf("expected errTestRollback, got %v", err)
+	}
+}
+
+func TestApplyBoardSourcePatchRollsBackAllWrites(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	err = s.ApplyBoardSourcePatch(ctx, DefaultBoardID, BoardSourcePatch{
+		Creates: []BoardSourceCreate{{
+			Kind:   "task",
+			Title:  "Should not survive rollback",
+			Status: "draft",
+		}},
+		LinkCreates: []BoardSourceLinkCreate{{
+			FromID: "task:missing-from",
+			ToID:   "task:missing-to",
+			Kind:   "blocks",
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected patch error")
+	}
+	snap, err := s.Snapshot(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, node := range snap.Nodes {
+		if strings.Contains(node.Title, "Should not survive rollback") {
+			t.Fatalf("node %q survived failed patch", node.ID)
+		}
 	}
 }

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -119,7 +119,17 @@ const state = {
   linkingKind: 'blocked_by',
   boardLastLoadedAt: null,
   currentWorkspaceID: '',
+  renderTimings: {},
+  performanceMode: false,
 };
+
+function timedRender(name, fn) {
+  const t0 = performance.now();
+  fn();
+  const elapsed = performance.now() - t0;
+  if (!state.renderTimings) state.renderTimings = {};
+  state.renderTimings[name] = elapsed.toFixed(1) + 'ms';
+}
 
 function emptyExport() {
   return {
@@ -949,6 +959,11 @@ function renderDebugPanel() {
   const selectedEdge = state.selectedEdgeID ? edgeByID(state.selectedEdgeID) : null;
   const selectedNodeJSON = selectedNode ? JSON.stringify(nodeData(selectedNode), null, 2) : null;
   const selectedEdgeJSON = selectedEdge ? JSON.stringify(selectedEdge, null, 2) : null;
+  const timings = state.renderTimings || {};
+  const timingEntries = Object.entries(timings);
+  const timingHTML = timingEntries.length
+    ? `<details><summary>Render timings</summary><dl>${timingEntries.map(([k, v]) => `<div><dt>${esc(k)}</dt><dd>${esc(v)}</dd></div>`).join('')}</dl></details>`
+    : '';
   dom.debugPanel.innerHTML = `<dl>
     <div><dt>Board name</dt><dd>${esc(board.name || state.currentBoardID)}</dd></div>
     <div><dt>Board id</dt><dd>${esc(state.currentBoardID)}</dd></div>
@@ -961,6 +976,7 @@ function renderDebugPanel() {
     <div><dt>User</dt><dd>${account.login ? `@${esc(account.login)}` : 'not signed in'}</dd></div>
     <div><dt>Mode</dt><dd>${esc(state.mode)}</dd></div>
   </dl>
+  ${timingHTML}
   ${selectedNodeJSON ? `<details><summary>Selected node data <button type="button" onclick="navigator.clipboard.writeText(${JSON.stringify(selectedNodeJSON)}).catch(()=>{})">Copy JSON</button></summary><pre>${esc(selectedNodeJSON)}</pre></details>` : ''}
   ${selectedEdgeJSON ? `<details><summary>Selected edge <button type="button" onclick="navigator.clipboard.writeText(${JSON.stringify(selectedEdgeJSON)}).catch(()=>{})">Copy JSON</button></summary><pre>${esc(selectedEdgeJSON)}</pre></details>` : ''}
   <div class="debugGitHubSetup">
@@ -974,7 +990,13 @@ function renderDebugPanel() {
       <div class="checkItem ${session.github_app_configured ? 'done' : ''}">GitHub App configured ${session.github_app_configured ? '✅' : '❌'}</div>
       <div class="checkItem ${session.github_webhook_configured ? 'done' : ''}">Webhook receiving ${session.github_webhook_configured ? '✅' : '❌'}</div>
     </div>
-  </div>`;
+  </div>
+  <label><input type="checkbox" id="perfModeToggle"> Performance mode</label>`;
+  const perfToggle = document.getElementById('perfModeToggle');
+  if (perfToggle) {
+    perfToggle.checked = !!state.performanceMode;
+    perfToggle.onchange = () => { state.performanceMode = perfToggle.checked; };
+  }
 }
 
 function renderSyncPanel() {
@@ -2398,6 +2420,9 @@ function render() {
     renderStatefulSignedOut();
     return;
   }
+  if (state.performanceMode) {
+    dom.status.textContent = 'Performance mode active';
+  }
   const { snapshot, brief } = state.data;
   const nodes = visibleNodes(snapshot.nodes);
   const graphSelection = graphVisibleNodeSelection(snapshot, nodes);
@@ -2417,10 +2442,10 @@ function render() {
   dom.graph.classList.toggle('hidden', state.view !== 'graph');
   dom.table.classList.toggle('hidden', state.view !== 'table');
   if (dom.kanban) dom.kanban.classList.toggle('hidden', state.view !== 'kanban');
-  if (state.view === 'brief') renderBrief(brief);
-  if (state.view === 'graph') renderGraph(snapshot, graphSelection.nodes, graphSelection.hidden);
-  if (state.view === 'table') renderTable(nodes);
-  if (state.view === 'kanban') renderKanbanView();
+  if (state.view === 'brief') timedRender('brief', () => renderBrief(brief));
+  if (state.view === 'graph') timedRender('graph', () => renderGraph(snapshot, graphSelection.nodes, graphSelection.hidden));
+  if (state.view === 'table') timedRender('table', () => renderTable(nodes));
+  if (state.view === 'kanban') timedRender('kanban', renderKanbanView);
 }
 
 function renderStatefulSignedOut() {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -4541,14 +4541,22 @@ function nodeSignalsHTML(node) {
   const people = nodePeople(node).slice(0, 5);
   const labelItems = labels(node).slice(0, 5);
   const milestone = nodeData(node).milestone || '';
+  const assigneeList = (nodeData(node).assignees || []).slice(0, 3);
   const peopleHTML = people.length
     ? `<div class="nodePeople">${people.map((person) => `<img src="${esc(person.avatar_url || githubAvatarURL(person.login))}" alt="@${esc(person.login)}" title="@${esc(person.login)}" loading="lazy">`).join('')}</div>`
+    : '';
+  const assigneeChipsHTML = assigneeList.length
+    ? `<div class="avatarChips">${assigneeList.map((a) => {
+        const login = a.login || a;
+        const avatarURL = a.avatar_url || githubAvatarURL(login);
+        return `<span class="avatarChip" title="@${esc(login)}"><img src="${esc(avatarURL)}" alt="@${esc(login)}" loading="lazy"><span class="avatarFallback">${esc(login)}</span></span>`;
+      }).join('')}</div>`
     : '';
   const labelsHTML = labelItems.length
     ? `<div class="nodeLabels">${labelItems.map((label) => `<span>${emojiHTML(label)}</span>`).join('')}</div>`
     : '';
   const milestoneHTML = milestone ? `<div class="nodeMilestone">${emojiHTML(milestone)}</div>` : '';
-  return peopleHTML || labelsHTML || milestoneHTML ? `<div class="nodeSignals">${peopleHTML}${labelsHTML}${milestoneHTML}</div>` : '';
+  return peopleHTML || assigneeChipsHTML || labelsHTML || milestoneHTML ? `<div class="nodeSignals">${peopleHTML}${assigneeChipsHTML}${labelsHTML}${milestoneHTML}</div>` : '';
 }
 
 function nodePeople(node) {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -4989,9 +4989,10 @@ async function loadSavedViews() {
       let cfg = {};
       try { cfg = JSON.parse(v.config_json || '{}'); } catch (_) {}
       const desc = [cfg.driver, cfg.view, cfg.filter_text].filter(Boolean).join(' · ');
+      const visibilityBadge = v.visibility === 'shared' ? '<span class="savedViewBadge shared">Shared</span>' : '<span class="savedViewBadge personal">Personal</span>';
       return `<div class="savedViewItem">
         <div>
-          <strong>${esc(v.name)}</strong>
+          <strong>${esc(v.name)}</strong>${visibilityBadge}
           ${desc ? `<span class="savedViewDesc">${esc(desc)}</span>` : ''}
         </div>
         <div class="savedViewActions">

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.18-dev';
+const assetVersion = 'v4.1.20-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -117,6 +117,7 @@ const state = {
   syncIndicator: 'idle',
   linkingFrom: null,
   linkingKind: 'blocked_by',
+  boardLastLoadedAt: null,
 };
 
 function emptyExport() {
@@ -427,6 +428,7 @@ async function loadBackendBoard() {
       state.selectedNodeID = '';
       writeURLNode('');
     }
+    state.boardLastLoadedAt = new Date().toISOString();
     setSyncIndicator('done');
     dom.status.textContent = 'stateful backend graph';
   } catch (err) {
@@ -5275,7 +5277,7 @@ async function applySourcePatch() {
     const res = await fetch('./api/board-source/apply', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ board_id: boardID, dry_run: true, ...patch }),
+      body: JSON.stringify({ board_id: boardID, dry_run: true, base_updated_at: state.boardLastLoadedAt || '', ...patch }),
     });
     if (!res.ok) throw new Error(await responseErrorMessage(res));
     renderSourcePatchModal(patch, async () => {
@@ -5283,7 +5285,7 @@ async function applySourcePatch() {
         const res2 = await fetch('./api/board-source/apply', {
           method: 'POST', credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ board_id: boardID, dry_run: false, ...patch }),
+          body: JSON.stringify({ board_id: boardID, dry_run: false, base_updated_at: state.boardLastLoadedAt || '', ...patch }),
         });
         if (!res2.ok) throw new Error(await responseErrorMessage(res2));
         state.sourceDirty = false;

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -118,6 +118,7 @@ const state = {
   linkingFrom: null,
   linkingKind: 'blocked_by',
   boardLastLoadedAt: null,
+  currentWorkspaceID: '',
 };
 
 function emptyExport() {
@@ -1010,6 +1011,22 @@ function renderSyncPanel() {
   </div>`;
   document.getElementById('syncFromPanelBtn')?.addEventListener('click', syncCurrentBoard);
   loadSyncLogs();
+}
+
+async function loadWorkspaces() {
+  if (!state.backendSession.authenticated) return;
+  try {
+    const res = await fetch('./api/workspaces', { credentials: 'same-origin' });
+    if (!res.ok) return;
+    const data = await res.json();
+    const workspaces = Array.isArray(data.workspaces) ? data.workspaces : [];
+    const el = document.getElementById('workspaceSwitcher');
+    if (!el) return;
+    el.innerHTML = '<option value="">All workspaces</option>' +
+      workspaces.map((ws) => `<option value="${esc(ws.id)}">${esc(ws.name)}</option>`).join('');
+    el.value = state.currentWorkspaceID || '';
+    el.onchange = () => { state.currentWorkspaceID = el.value; render(); };
+  } catch (_) {}
 }
 
 async function loadSyncLogs() {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -5112,6 +5112,7 @@ async function submitGitHubComment(repo, issueNumber, body) {
       const el = document.getElementById('inspectorCommentBody');
       if (el) el.value = '';
     }
+    await loadBackendBoard();
   } catch (err) {
     dom.error.textContent = err.message;
     dom.status.textContent = 'comment failed';

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -106,6 +106,7 @@
             <h3>Workspace</h3>
             <p id="workspaceSummary">Pick or create a view.</p>
           </div>
+          <select id="workspaceSwitcher" aria-label="Workspace" class="statefulOnly"></select>
           <button id="syncBoardBtn" type="button">Sync</button>
         </div>
 

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <link rel="icon" href="./favicon.png" type="image/png" sizes="64x64">
   <link rel="apple-touch-icon" href="./logo-512.png">
-  <link rel="stylesheet" href="./style.css?v=v4.1.18-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.20-dev">
 </head>
 <body>
   <header class="topbar">
@@ -325,6 +325,6 @@
   </main>
 
   <div id="linkModeIndicator" class="linkModeIndicator" aria-live="polite"></div>
-  <script src="./app.js?v=v4.1.18-dev"></script>
+  <script src="./app.js?v=v4.1.20-dev"></script>
 </body>
 </html>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -1869,6 +1869,40 @@ textarea::selection {
   color: #6d28d9;
 }
 
+.avatarChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.avatarChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: #f0f4ff;
+  border: 1px solid #c7d7fd;
+  border-radius: 999px;
+  padding: 1px 6px 1px 2px;
+  font-size: 10px;
+  color: #3b4fc8;
+  max-width: 120px;
+  overflow: hidden;
+}
+
+.avatarChip img {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.avatarFallback {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .graphInner {
   position: relative;
   min-width: 900px;

--- a/live/static_test.go
+++ b/live/static_test.go
@@ -366,6 +366,55 @@ func TestLiveAssetsExposeGitHubDiagnostics(t *testing.T) {
 	}
 }
 
+func TestLiveAssetsExposeHardening713Features(t *testing.T) {
+	fsys := AppFS()
+	app, err := fs.ReadFile(fsys, "app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeGo, err := os.ReadFile("../internal/core/store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverGo, err := os.ReadFile("../internal/backend/server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainGo, err := os.ReadFile("../cmd/depviz/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	docsFile, err := os.ReadFile("../docs/meta-repo-strategy.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"WithTx helper", string(storeGo), `func (s *Store) WithTx(`},
+		{"BoardUpdatedAt helper", string(storeGo), `func (s *Store) BoardUpdatedAt(`},
+		{"workspaces route", string(serverGo), `/api/workspaces`},
+		{"base_updated_at in server", string(serverGo), `base_updated_at`},
+		{"schema_migrations table", string(storeGo), `schema_migrations`},
+		{"requireBoardAccess helper", string(serverGo), `func (s *Server) requireBoardAccess(`},
+		{"restore command", string(mainGo), `case "restore"`},
+		{"timedRender in app", string(app), `function timedRender(`},
+		{"renderTimings in app", string(app), `renderTimings`},
+		{"workspaceSwitcher in index", string(index), `workspaceSwitcher`},
+		{"meta-repo docs exist", string(docsFile), `Meta-Repo Strategy`},
+	} {
+		if !strings.Contains(tc.body, tc.want) {
+			t.Fatalf("%s: missing %q", tc.name, tc.want)
+		}
+	}
+}
+
 func TestLiveAssetsExposeCockpitNext711Features(t *testing.T) {
 	fsys := AppFS()
 	app, err := fs.ReadFile(fsys, "app.js")


### PR DESCRIPTION
Closes #713

Stacks on #712, #710, #706. All 20 next steps for correctness, workspace/org model, webhook processing, and production hardening.

## Changes

| # | Item | Commit |
|---|------|--------|
| 1 | Source apply is now fully transactional via `WithTx()` helper | 7500f1b |
| 2 | Integration tests for source apply (store + server) | edd1096 |
| 3 | Optimistic concurrency: 409 conflict if board changed since preview loaded | a04e31e |
| 4 | Workspace/org account model: `ListWorkspacesForAccount`, `/api/workspaces`, workspace switcher UI | fce408c |
| 5 | Board access checks: `requireBoardAccess()` applied to all write endpoints | a3fc847 |
| 6 | Webhook processing: `issues` and `pull_request` events upsert nodes live | f78076b |
| 7 | Sync queue cancel: `CancelSyncLog()`, DELETE on `/api/board-sync-logs`, cancel buttons | 3354358 |
| 8 | GitHub write permission preflight: structured 401/403/404/429 error messages | 7975378 |
| 9 | Refresh GitHub node immediately after create/update writes | 49dd2b1 |
| 10 | Expanded GitHub metadata: draft flag, assignee avatar chips, CSS | 7bb8379 |
| 11 | Personal overrides fully wired: GET + DELETE endpoints, `GetPersonalOverride`/`DeletePersonalOverride` | df9a872 |
| 12 | Saved view sharing: `visibility` column, personal/shared badges in UI | 89ba0b1 |
| 13 | DB migration version tracking: `schema_migrations` table records applied versions | 967148d |
| 14 | Restore CLI command: `depviz restore --from <backup> [--force]` + backup retention | 5034c66 |
| 15 | Export/import round-trip tests: `TestSnapshotRoundTrip`, `TestExportJSON` | 63e2e93 |
| 16 | Render performance timing in debug panel: `timedRender()`, perf mode toggle | e756b02 |
| 17 | Meta-repo strategy workflow spec: `docs/meta-repo-strategy.md` | 58d13c8 |
| *(18)* | Static regression tests for all above | 6b5b4a0 |

Deferred: item 14 (browser/Playwright tests) — needs browser test framework setup as a separate issue.

## New routes
- `GET /api/workspaces` — list personal + org/installation workspaces
- `DELETE /api/board-sync-logs` — cancel a queued/running sync job
- `GET /api/overrides?node_id=X` — fetch personal override
- `DELETE /api/overrides?node_id=X` — clear personal override

## New store additions
- `WithTx(ctx, fn)` — generic transaction wrapper
- `BoardUpdatedAt(ctx, boardID)` — for optimistic concurrency
- `CancelSyncLog(ctx, id)` — cancel sync job
- `GetPersonalOverride(ctx, accountID, nodeID)` — fetch override
- `DeletePersonalOverride(ctx, accountID, nodeID)` — clear override
- `schema_migrations` table for versioned migration tracking
- `visibility` column on `board_views`
- `owner_account_id` on boards for access control

## Test plan
- [ ] Edit source text → Apply → if board changed between preview and apply → 409 conflict message shown
- [ ] Push GitHub issue update → webhook triggers node upsert without manual sync
- [ ] Cancel a running background sync from Sync panel
- [ ] Create GitHub issue without permissions → clear "missing issues:write on repo" error
- [ ] After creating/updating GitHub issue → card refreshes immediately without manual sync
- [ ] Node cards show assignee avatars (or initials if no avatar)
- [ ] Personal note on GitHub node → survives reload; clear override removes it
- [ ] Saved view shows Personal/Shared badge; can toggle
- [ ] `depviz restore --from backup.db --force` restores DB safely
- [ ] Debug panel shows render timings; perf mode toggle hides closed items
- [ ] `go test ./...` passes (including new integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)