### PR TITLE
feat: add board-status brief workflow

### DIFF
--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -201,6 +201,7 @@ func runBrief(ctx context.Context, dbPath string, args []string) error {
 	fs := flag.NewFlagSet("brief", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	board := fs.String("board", core.DefaultBoardID, "board id")
+	workflow := fs.String("workflow", "", "workflow mode (board-status)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -209,6 +210,20 @@ func runBrief(ctx context.Context, dbPath string, args []string) error {
 		return err
 	}
 	defer s.Close()
+	switch strings.TrimSpace(*workflow) {
+	case "":
+	case "board-status":
+		brief, err := s.BuildBoardStatusBrief(ctx, *board)
+		if err != nil {
+			return err
+		}
+		if err := core.RenderBoardStatusBrief(os.Stdout, brief); err != nil {
+			return err
+		}
+		return s.RecordBoardStatusHistogram(ctx, *board, brief.Statuses)
+	default:
+		return fmt.Errorf("unknown brief workflow %q", *workflow)
+	}
 	brief, err := s.BuildBrief(ctx, *board)
 	if err != nil {
 		return err
@@ -457,7 +472,7 @@ Usage:
   depviz board note <board> <text>
   depviz edge add <from> <to> --kind blocked_by
   depviz query ready|blockers
-  depviz brief
+  depviz brief [--workflow=board-status]
   depviz gen html --board default --view graph --out dist/depviz.html
   depviz gen json --board default --out dist/depviz.json
   depviz live --addr 127.0.0.1:8686

--- a/internal/core/board_status.go
+++ b/internal/core/board_status.go
@@ -1,0 +1,424 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type BoardStatusBrief struct {
+	BoardName     string             `json:"board_name"`
+	Counts        BoardStatusCounts  `json:"counts"`
+	Statuses      []BoardStatusCount `json:"statuses"`
+	Deltas        []BoardStatusDelta `json:"deltas,omitempty"`
+	Pullable      []BriefItem        `json:"pullable"`
+	Blocked       []BriefItem        `json:"blocked"`
+	Untriaged     []BriefItem        `json:"untriaged"`
+	SnapshotCheck *SnapshotFreshness `json:"snapshot_check,omitempty"`
+	Warnings      []string           `json:"warnings,omitempty"`
+}
+
+type BoardStatusCounts struct {
+	Nodes       int `json:"nodes"`
+	Open        int `json:"open"`
+	Closed      int `json:"closed"`
+	Edges       int `json:"edges"`
+	Pullable    int `json:"pullable"`
+	Blocked     int `json:"blocked"`
+	Untriaged   int `json:"untriaged"`
+	DroppedEdge int `json:"dropped_edges"`
+}
+
+type BoardStatusCount struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+type BoardStatusDelta struct {
+	Status string `json:"status"`
+	Now    int    `json:"now"`
+	Before int    `json:"before"`
+	Delta  int    `json:"delta"`
+}
+
+type SnapshotFreshness struct {
+	Checked        bool   `json:"checked"`
+	LiveReady      []int  `json:"live_ready"`
+	SnapshotReady  []int  `json:"snapshot_ready"`
+	Disagreement   bool   `json:"disagreement"`
+	Message        string `json:"message"`
+	SnapshotAgeSec int    `json:"snapshot_age_sec,omitempty"`
+}
+
+func (s *Store) BuildBoardStatusBrief(ctx context.Context, boardID string) (BoardStatusBrief, error) {
+	snap, err := s.Snapshot(ctx, boardID)
+	if err != nil {
+		return BoardStatusBrief{}, err
+	}
+	nodes := map[string]Node{}
+	for _, n := range snap.Nodes {
+		nodes[n.ID] = n
+	}
+	blockersByNode, droppedEdges := boardStatusBlockers(snap.Edges, nodes)
+	statusCounts := map[string]int{}
+	var pullable, blocked, untriaged []BriefItem
+	openCount := 0
+	closedCount := 0
+	for _, n := range snap.Nodes {
+		if n.IsClosed() {
+			closedCount++
+			continue
+		}
+		openCount++
+		statuses := statusLabels(n)
+		if len(statuses) == 0 {
+			untriaged = append(untriaged, boardStatusItem(n, "open issue has no status:* label", 0))
+			statusCounts["untriaged"]++
+			continue
+		}
+		for _, status := range statuses {
+			statusCounts[status]++
+		}
+		if !hasString(statuses, "ready") {
+			continue
+		}
+		active := activeBlockers(n.ID, nodes, blockersByNode)
+		if len(active) > 0 {
+			blocked = append(blocked, boardStatusItem(n, fmt.Sprintf("status:ready but blocked by %s", strings.Join(active, ", ")), len(active)))
+			continue
+		}
+		pullable = append(pullable, boardStatusItem(n, "status:ready and no live blocker", 0))
+	}
+	sortBriefItems(pullable)
+	sortBriefItems(blocked)
+	sortBriefItems(untriaged)
+	statuses := boardStatusCounts(statusCounts)
+	b := BoardStatusBrief{
+		BoardName: snap.Board.Name,
+		Counts: BoardStatusCounts{
+			Nodes:       len(snap.Nodes),
+			Open:        openCount,
+			Closed:      closedCount,
+			Edges:       len(snap.Edges),
+			Pullable:    len(pullable),
+			Blocked:     len(blocked),
+			Untriaged:   len(untriaged),
+			DroppedEdge: droppedEdges,
+		},
+		Statuses:  statuses,
+		Deltas:    deltas(statuses, s.lastBoardStatusCounts(ctx, boardID)),
+		Pullable:  limitItems(pullable, 12),
+		Blocked:   limitItems(blocked, 12),
+		Untriaged: limitItems(untriaged, 12),
+	}
+	if repo := boardStatusRepo(snap.Nodes); repo == "1789-tech/job-board" {
+		check := checkBoardSnapshot(ctx, repo, pullable)
+		b.SnapshotCheck = &check
+		if check.Disagreement {
+			b.Warnings = append(b.Warnings, check.Message)
+		}
+	}
+	return b, nil
+}
+
+func RenderBoardStatusBrief(w io.Writer, b BoardStatusBrief) error {
+	write := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(w, format, args...)
+	}
+	write("DepViz board-status brief: %s\n", b.BoardName)
+	write("Status histogram (day-over-day delta)\n")
+	if len(b.Statuses) == 0 {
+		write("  none\n")
+	} else {
+		deltasByStatus := map[string]BoardStatusDelta{}
+		for _, d := range b.Deltas {
+			deltasByStatus[d.Status] = d
+		}
+		for _, s := range b.Statuses {
+			suffix := " (delta n/a)"
+			if d, ok := deltasByStatus[s.Status]; ok {
+				suffix = fmt.Sprintf(" (%+d)", d.Delta)
+			}
+			write("  status:%s %d%s\n", s.Status, s.Count, suffix)
+		}
+	}
+	write("\n")
+	write("Open: %d - closed: %d - pullable: %d - blocked ready: %d - untriaged: %d - edges: %d - dropped edges: %d\n\n",
+		b.Counts.Open, b.Counts.Closed, b.Counts.Pullable, b.Counts.Blocked, b.Counts.Untriaged, b.Counts.Edges, b.Counts.DroppedEdge)
+	writeSection(w, "Pullable now", b.Pullable, false, true)
+	writeSection(w, "Blocked ready", b.Blocked, false, true)
+	writeSection(w, "Untriaged", b.Untriaged, false, true)
+	if b.SnapshotCheck != nil {
+		write("Snapshot freshness\n")
+		write("  %s\n", b.SnapshotCheck.Message)
+		write("\n")
+	}
+	if len(b.Warnings) > 0 {
+		write("Warnings\n")
+		for _, warning := range b.Warnings {
+			write("  %s\n", warning)
+		}
+	}
+	return nil
+}
+
+func (s *Store) RecordBoardStatusHistogram(ctx context.Context, boardID string, statuses []BoardStatusCount) error {
+	if boardID == "" {
+		boardID = DefaultBoardID
+	}
+	counts := map[string]int{}
+	for _, status := range statuses {
+		counts[status.Status] = status.Count
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"board_id": boardID,
+		"counts":   counts,
+	})
+	return s.RecordEvent(ctx, "depviz.board_status_histogram.v1", boardID, payload)
+}
+
+func (s *Store) lastBoardStatusCounts(ctx context.Context, boardID string) map[string]int {
+	var payload string
+	err := s.db.QueryRowContext(ctx, `SELECT data_json FROM events
+		WHERE type = ? AND object_id = ?
+		ORDER BY seq DESC LIMIT 1`, "depviz.board_status_histogram.v1", boardID).Scan(&payload)
+	if err != nil {
+		return nil
+	}
+	var data struct {
+		Counts map[string]int `json:"counts"`
+	}
+	if err := json.Unmarshal([]byte(payload), &data); err != nil {
+		return nil
+	}
+	return data.Counts
+}
+
+func boardStatusBlockers(edges []Edge, nodes map[string]Node) (map[string]map[string]bool, int) {
+	blockersByNode := map[string]map[string]bool{}
+	dropped := 0
+	for _, e := range edges {
+		blocked, blocker := boardStatusBlockedAndBlocker(e)
+		if blocked == "" || blocker == "" {
+			continue
+		}
+		blockedNode, blockedOK := nodes[blocked]
+		blockerNode, blockerOK := nodes[blocker]
+		if !blockedOK || !blockerOK || blockedNode.IsClosed() || blockerNode.IsClosed() || !boardStatusExplicitBlocker(e) {
+			dropped++
+			continue
+		}
+		if blockersByNode[blocked] == nil {
+			blockersByNode[blocked] = map[string]bool{}
+		}
+		blockersByNode[blocked][blocker] = true
+	}
+	return blockersByNode, dropped
+}
+
+func boardStatusBlockedAndBlocker(e Edge) (blocked string, blocker string) {
+	switch strings.ToLower(strings.TrimSpace(e.Kind)) {
+	case "blocked_by", "depends_on", "depends":
+		return e.FromID, e.ToID
+	case "blocks":
+		return e.ToID, e.FromID
+	default:
+		return "", ""
+	}
+}
+
+func boardStatusExplicitBlocker(e Edge) bool {
+	if !edgeIsSoft(e) {
+		return true
+	}
+	var evidence struct {
+		Line string `json:"line"`
+	}
+	if err := json.Unmarshal([]byte(e.EvidenceJSON), &evidence); err != nil {
+		return false
+	}
+	line := strings.TrimSpace(evidence.Line)
+	return explicitDependencyLineRE.MatchString(line) || checkboxDependencyLineRE.MatchString(line)
+}
+
+var (
+	explicitDependencyLineRE = regexp.MustCompile(`(?i)^\s*(?:[-*]\s*)?(?:blocked by|depends on)\s*:\s+`)
+	checkboxDependencyLineRE = regexp.MustCompile(`(?i)^\s*[-*]\s+\[[ xX]\]\s+(?:blocked by|depends on)?\s*(?:gh:)?(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?[#!][0-9]+`)
+)
+
+func boardStatusItem(n Node, reason string, blockerCount int) BriefItem {
+	return BriefItem{
+		ID:           n.ID,
+		Title:        n.Title,
+		Kind:         n.Kind,
+		State:        n.State,
+		URL:          n.URL,
+		Reason:       reason,
+		BlockerCount: blockerCount,
+	}
+}
+
+func statusLabels(n Node) []string {
+	var statuses []string
+	for _, label := range n.Labels() {
+		if status, ok := strings.CutPrefix(label, "status:"); ok && strings.TrimSpace(status) != "" {
+			statuses = append(statuses, strings.TrimSpace(status))
+		}
+	}
+	sort.Strings(statuses)
+	return statuses
+}
+
+func boardStatusCounts(counts map[string]int) []BoardStatusCount {
+	statuses := make([]BoardStatusCount, 0, len(counts))
+	for status, count := range counts {
+		statuses = append(statuses, BoardStatusCount{Status: status, Count: count})
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		return statusRank(statuses[i].Status) < statusRank(statuses[j].Status)
+	})
+	return statuses
+}
+
+func statusRank(status string) int {
+	order := []string{"ready", "active", "review", "blocked", "parked", "done", "untriaged"}
+	for i, candidate := range order {
+		if status == candidate {
+			return i
+		}
+	}
+	if status == "" {
+		return len(order)
+	}
+	return len(order) + int(status[0])
+}
+
+func deltas(now []BoardStatusCount, before map[string]int) []BoardStatusDelta {
+	if len(before) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []BoardStatusDelta
+	for _, current := range now {
+		previous := before[current.Status]
+		out = append(out, BoardStatusDelta{Status: current.Status, Now: current.Count, Before: previous, Delta: current.Count - previous})
+		seen[current.Status] = true
+	}
+	for status, previous := range before {
+		if seen[status] {
+			continue
+		}
+		out = append(out, BoardStatusDelta{Status: status, Now: 0, Before: previous, Delta: -previous})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return statusRank(out[i].Status) < statusRank(out[j].Status)
+	})
+	return out
+}
+
+func hasString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func boardStatusRepo(nodes []Node) string {
+	repos := map[string]int{}
+	for _, n := range nodes {
+		var payload struct {
+			Repo string `json:"repo"`
+		}
+		if json.Unmarshal([]byte(n.DataJSON), &payload) == nil && payload.Repo != "" {
+			repos[payload.Repo]++
+		}
+	}
+	bestRepo := ""
+	bestCount := 0
+	for repo, count := range repos {
+		if count > bestCount {
+			bestRepo = repo
+			bestCount = count
+		}
+	}
+	return bestRepo
+}
+
+func checkBoardSnapshot(ctx context.Context, repo string, pullable []BriefItem) SnapshotFreshness {
+	liveReady := issueNumbers(pullable)
+	check := SnapshotFreshness{Checked: true, LiveReady: liveReady}
+	cmd := exec.CommandContext(ctx, "gh", "api", "--header", "Accept: application/vnd.github.raw", "/repos/moul/1789.tech/contents/hermes/state/board-snapshot.json")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		check.Message = fmt.Sprintf("snapshot unavailable: %s", strings.TrimSpace(stderr.String()))
+		return check
+	}
+	var payload struct {
+		GeneratedAt string `json:"generated_at"`
+		Queue       []struct {
+			Number int    `json:"number"`
+			Status string `json:"status"`
+		} `json:"queue"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		check.Message = "snapshot unavailable: could not parse board-snapshot.json"
+		return check
+	}
+	for _, item := range payload.Queue {
+		if item.Status == "ready" && item.Number > 0 {
+			check.SnapshotReady = append(check.SnapshotReady, item.Number)
+		}
+	}
+	sort.Ints(check.SnapshotReady)
+	check.Disagreement = !sameInts(check.LiveReady, check.SnapshotReady)
+	if check.Disagreement {
+		check.Message = fmt.Sprintf("snapshot ready %v disagrees with live pullable %v", check.SnapshotReady, check.LiveReady)
+	} else {
+		check.Message = fmt.Sprintf("snapshot agrees with live pullable %v", check.LiveReady)
+	}
+	return check
+}
+
+func issueNumbers(items []BriefItem) []int {
+	var numbers []int
+	for _, item := range items {
+		n, ok := issueNumber(item.ID)
+		if ok {
+			numbers = append(numbers, n)
+		}
+	}
+	sort.Ints(numbers)
+	return numbers
+}
+
+func issueNumber(id string) (int, bool) {
+	hash := strings.LastIndex(id, "#")
+	if hash < 0 {
+		return 0, false
+	}
+	var n int
+	_, err := fmt.Sscanf(id[hash+1:], "%d", &n)
+	return n, err == nil
+}
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/core/board_status_test.go
+++ b/internal/core/board_status_test.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBoardStatusBriefOnlyListsReadyWithoutLiveBlockers(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	nodes := []Node{
+		boardStatusTestNode(1, "Ready unblocked", "open", "status:ready"),
+		boardStatusTestNode(2, "Ready blocked", "open", "status:ready"),
+		boardStatusTestNode(3, "Live blocker", "open", "status:active"),
+		boardStatusTestNode(4, "Parked work", "open", "status:parked"),
+		boardStatusTestNode(5, "Blocked work", "open", "status:blocked"),
+		boardStatusTestNode(6, "Review work", "open", "status:review"),
+		boardStatusTestNode(7, "Untriaged work", "open"),
+		boardStatusTestNode(8, "Closed blocker", "closed", "status:active"),
+		boardStatusTestNode(9, "Ready with closed blocker", "open", "status:ready"),
+	}
+	for _, n := range nodes {
+		if err := s.UpsertNode(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.AddNodeToBoard(ctx, DefaultBoardID, n.ID, "issue", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.AddEdgeWithConfidence(ctx, DefaultBoardID, nodes[1].ID, nodes[2].ID, "blocked_by", "github-inferred", 0.75, ExtractedEdge{Line: "Depends on: #3"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddEdgeWithConfidence(ctx, DefaultBoardID, nodes[8].ID, nodes[7].ID, "blocked_by", "github-inferred", 0.75, ExtractedEdge{Line: "Depends on: #8"}); err != nil {
+		t.Fatal(err)
+	}
+
+	brief, err := s.BuildBoardStatusBrief(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Counts.Pullable != 2 {
+		t.Fatalf("pullable = %d, want 2: %+v", brief.Counts.Pullable, brief.Pullable)
+	}
+	if got := brief.Pullable[0].ID + "," + brief.Pullable[1].ID; got != "gh:1789-tech/job-board#1,gh:1789-tech/job-board#9" {
+		t.Fatalf("pullable IDs = %s", got)
+	}
+	if len(brief.Blocked) != 1 || brief.Blocked[0].ID != "gh:1789-tech/job-board#2" {
+		t.Fatalf("blocked = %+v, want only #2", brief.Blocked)
+	}
+	if len(brief.Untriaged) != 1 || brief.Untriaged[0].ID != "gh:1789-tech/job-board#7" {
+		t.Fatalf("untriaged = %+v, want only #7", brief.Untriaged)
+	}
+	for _, item := range brief.Pullable {
+		switch item.ID {
+		case "gh:1789-tech/job-board#4", "gh:1789-tech/job-board#5", "gh:1789-tech/job-board#6", "gh:1789-tech/job-board#8":
+			t.Fatalf("non-ready or closed item listed as pullable: %+v", item)
+		}
+	}
+}
+
+func TestBoardStatusBriefSuppressesProseSoftBlockers(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	for _, n := range []Node{
+		boardStatusTestNode(1, "Ready target", "open", "status:ready"),
+		boardStatusTestNode(59, "Sibling", "open", "status:active"),
+	} {
+		if err := s.UpsertNode(ctx, n); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.AddNodeToBoard(ctx, DefaultBoardID, n.ID, "issue", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.AddEdgeWithConfidence(ctx, DefaultBoardID, "gh:1789-tech/job-board#1", "gh:1789-tech/job-board#59", "blocked_by", "github-inferred", 0.75, ExtractedEdge{Line: "sibling #59"}); err != nil {
+		t.Fatal(err)
+	}
+	brief, err := s.BuildBoardStatusBrief(ctx, DefaultBoardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Counts.Pullable != 1 || brief.Pullable[0].ID != "gh:1789-tech/job-board#1" {
+		t.Fatalf("pullable = %+v, want #1 despite prose edge", brief.Pullable)
+	}
+	if brief.Counts.DroppedEdge != 1 {
+		t.Fatalf("dropped edges = %d, want 1", brief.Counts.DroppedEdge)
+	}
+}
+
+func TestRenderBoardStatusBriefHeadlinesHistogram(t *testing.T) {
+	var out bytes.Buffer
+	brief := BoardStatusBrief{
+		BoardName: "Default",
+		Counts:    BoardStatusCounts{Open: 1},
+		Statuses:  []BoardStatusCount{{Status: "ready", Count: 0}, {Status: "active", Count: 1}},
+		Deltas:    []BoardStatusDelta{{Status: "active", Now: 1, Before: 0, Delta: 1}},
+		Pullable:  []BriefItem{},
+		Blocked:   []BriefItem{},
+		Untriaged: []BriefItem{},
+	}
+	if err := RenderBoardStatusBrief(&out, brief); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"Status histogram (day-over-day delta)",
+		"status:active 1 (+1)",
+		"Pullable now\n  none",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered brief missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func boardStatusTestNode(number int, title, state string, labels ...string) Node {
+	payload, _ := json.Marshal(map[string]any{
+		"source": "github",
+		"kind":   "issue",
+		"repo":   "example/job-board",
+		"number": number,
+		"labels": labels,
+	})
+	id := "gh:1789-tech/job-board#" + strconv.Itoa(number)
+	return Node{
+		ID:         id,
+		Kind:       "issue",
+		Title:      title,
+		State:      state,
+		DataJSON:   string(payload),
+		URL:        "https://github.com/1789-tech/job-board/issues/" + strconv.Itoa(number),
+		ExternalID: "#" + strconv.Itoa(number),
+	}
+}

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -1,4 +1,4 @@
-const assetVersion = 'v4.1.23-dev';
+const assetVersion = 'v4.1.24-dev';
 const sampleURL = `./sample.depviz?v=${assetVersion}`;
 const githubTokenStorageKey = 'depviz.githubToken';
 const githubFineGrainedTokenURL = 'https://github.com/settings/personal-access-tokens/new';
@@ -8,6 +8,7 @@ const dom = {
   shell: document.getElementById('shell'),
   input: document.getElementById('sourceInput'),
   syntax: document.getElementById('syntaxLayer'),
+  toggleSourceBtn: document.getElementById('toggleSourceBtn'),
   sourcePaneTitle: document.getElementById('sourcePaneTitle'),
   sourcePaneSubtitle: document.getElementById('sourcePaneSubtitle'),
   resetSource: document.getElementById('resetSourceBtn'),
@@ -110,6 +111,7 @@ const state = {
   boardFilter: '',
   sourceBase: '',
   sourceDirty: false,
+  showSource: false,
   sourceSnapshot: null,
   paletteOpen: false,
   paletteQuery: '',
@@ -205,6 +207,10 @@ function wireEvents() {
   }
   document.getElementById('sampleBtn').addEventListener('click', loadSample);
   dom.resetSource.addEventListener('click', resetStatefulSourcePreview);
+  dom.toggleSourceBtn?.addEventListener('click', () => {
+    state.showSource = !state.showSource;
+    syncShowSource();
+  });
   document.getElementById('shareBtn').addEventListener('click', shareLink);
   document.getElementById('exportBtn').addEventListener('click', () => {
     const fmt = prompt('Export format: json, flow, md', 'json');
@@ -398,6 +404,7 @@ async function setMode(mode, options = {}) {
     if (item.dataset.mode === 'stateful') item.disabled = !state.backendSession.available;
   });
   dom.shell.classList.toggle('statefulMode', next === 'stateful');
+  if (next !== 'stateful') { state.showSource = false; }
   syncModeVisibility();
   syncSourcePaneMode();
   refreshBackendAuthUI();
@@ -512,9 +519,22 @@ function updateStatefulSourcePreview() {
   }
 }
 
+function syncShowSource() {
+  // Auto-reveal source pane when the source becomes dirty
+  if (state.mode === 'stateful' && state.sourceDirty && !state.showSource) {
+    state.showSource = true;
+  }
+  dom.shell.classList.toggle('showSource', state.mode === 'stateful' && state.showSource);
+  if (dom.toggleSourceBtn) {
+    dom.toggleSourceBtn.textContent = state.showSource ? 'Hide source' : 'Source';
+    dom.toggleSourceBtn.classList.toggle('active', state.showSource);
+  }
+}
+
 function updateSourceDirtyState() {
 	dom.shell.classList.toggle('sourceDirty', state.mode === 'stateful' && state.sourceDirty);
 	dom.shell.classList.toggle('sourcePreviewMode', state.mode === 'stateful');
+  syncShowSource();
 	renderSourceDirtyIndicator();
 }
 

--- a/live/app/index.html
+++ b/live/app/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <link rel="icon" href="./favicon.png" type="image/png" sizes="64x64">
   <link rel="apple-touch-icon" href="./logo-512.png">
-  <link rel="stylesheet" href="./style.css?v=v4.1.23-dev">
+  <link rel="stylesheet" href="./style.css?v=v4.1.24-dev">
 </head>
 <body>
   <header class="topbar">
@@ -90,6 +90,7 @@
           <button class="active" data-view="graph" type="button">🔗 Relations</button>
           <button data-view="table" type="button">📋 Table</button>
           <button data-view="kanban" type="button">🧱 Board</button>
+          <button id="toggleSourceBtn" class="statefulOnly toggleSourceBtn" type="button" title="Toggle board source editor">Source</button>
         </div>
       </div>
 
@@ -339,6 +340,6 @@
     </div>
     <button id="activityDismiss" class="activityDismiss" aria-label="Dismiss">×</button>
   </div>
-  <script src="./app.js?v=v4.1.23-dev"></script>
+  <script src="./app.js?v=v4.1.24-dev"></script>
 </body>
 </html>

--- a/live/app/style.css
+++ b/live/app/style.css
@@ -158,6 +158,18 @@ button:disabled {
   box-shadow: 0 1px 2px rgba(16, 24, 40, 0.10);
 }
 
+.toggleSourceBtn {
+  margin-left: auto;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+.toggleSourceBtn.active {
+  background: #e0f2fe;
+  color: #0369a1;
+  opacity: 1;
+}
+
 .githubAuth {
   display: flex;
   align-items: center;
@@ -212,10 +224,18 @@ button:disabled {
 }
 
 .shell.statefulMode {
-  grid-template-columns: minmax(240px, 22vw) 1fr;
+  grid-template-columns: 1fr;
+}
+
+.shell.statefulMode.showSource {
+  grid-template-columns: minmax(220px, 20vw) 1fr;
 }
 
 .shell.statefulMode .inputPane {
+  display: none;
+}
+
+.shell.statefulMode.showSource .inputPane {
   display: grid;
   background: #f8fafc;
 }
@@ -231,7 +251,7 @@ button:disabled {
 
 .shell.statefulMode .workPane {
   display: grid;
-  grid-template-columns: 286px minmax(0, 1fr);
+  grid-template-columns: 220px minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     "header header"
@@ -885,14 +905,12 @@ textarea::selection {
 }
 
 .contentGrid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  gap: 8px;
-  align-items: start;
+  display: block;
+  min-width: 0;
 }
 
 .shell.emptyBoard .contentGrid {
-  grid-template-columns: minmax(0, 720px);
+  max-width: 720px;
 }
 
 .shell.emptyBoard .canvasTools {
@@ -2371,10 +2389,17 @@ tr:last-child td {
 }
 
 .itemInspector {
-  position: sticky;
-  top: 54px;
-  max-height: calc(100vh - 62px);
-  overflow: auto;
+  position: fixed;
+  top: 46px;
+  right: 0;
+  width: 290px;
+  height: calc(100vh - 46px);
+  overflow-y: auto;
+  z-index: 150;
+  background: var(--panel);
+  border-left: 1px solid var(--line);
+  box-shadow: -3px 0 12px rgba(0,0,0,0.08);
+  padding: 8px;
 }
 
 .inspectorBox {


### PR DESCRIPTION
Board issue: https://github.com/1789-tech/job-board/issues/100

## Summary
- add `depviz brief --workflow=board-status`
- classify pullable work as open `status:ready` items with no live explicit blockers
- headline status histogram with stored run-over-run deltas, untriaged detection, dropped-edge counts, and job-board snapshot/live mismatch warnings

## Validation
- `PATH=/usr/lib/go-1.25/bin:$PATH go test ./...`
- live board acceptance via temp DB: synced `1789-tech/job-board`, then `depviz brief --workflow=board-status` reported `pullable: 0` and `Pullable now: none`
