### PR TITLE
fix: SQLite WAL + busy_timeout so live server and sync stop racing (BRIEF-105)

### DIFF
--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -84,15 +84,15 @@ func OpenStore(ctx context.Context, path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", storeDSN(path))
 	if err != nil {
 		return nil, err
 	}
+	// WAL lets the live server read while a sync writes; busy_timeout absorbs
+	// the remaining lock windows so concurrent runs retry instead of failing
+	// with SQLITE_BUSY. Both, plus foreign_keys, are set via the DSN so they
+	// apply to every pooled connection — not just the first one.
 	s := &Store{db: db, path: path}
-	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
 	if err := s.Migrate(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -102,6 +102,18 @@ func OpenStore(ctx context.Context, path string) (*Store, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+// storeDSN appends the connection pragmas the driver applies to every pooled
+// connection. busy_timeout is per-connection (so it must live here, not in a
+// one-off Exec), journal_mode=WAL is persisted on the database file, and
+// foreign_keys is per-connection too.
+func storeDSN(path string) string {
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)"
 }
 
 func (s *Store) Close() error {

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -7,6 +7,39 @@ import (
 	"testing"
 )
 
+func TestOpenStoreConcurrencyPragmas(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenStore(ctx, t.TempDir()+"/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	var journal string
+	if err := s.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journal); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(journal, "wal") {
+		t.Fatalf("journal_mode = %q, want wal", journal)
+	}
+
+	var busy int
+	if err := s.db.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busy); err != nil {
+		t.Fatal(err)
+	}
+	if busy < 5000 {
+		t.Fatalf("busy_timeout = %d, want >= 5000", busy)
+	}
+
+	var fk int
+	if err := s.db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatal(err)
+	}
+	if fk != 1 {
+		t.Fatalf("foreign_keys = %d, want 1", fk)
+	}
+}
+
 func TestBriefWithLocalNoteAndBlockedIssue(t *testing.T) {
 	ctx := context.Background()
 	s, err := OpenStore(ctx, t.TempDir()+"/state.db")


### PR DESCRIPTION
## What

Open the SQLite store in **WAL mode with a 5s `busy_timeout`**, applied via the DSN so the pragmas reach *every* pooled connection.

## Why (BRIEF-105)

BRIEF-105 asks for the `depviz brief --workflow=board-status` POC to run reliably on the real `1789-tech/job-board`, and names **"Fix WAL/SQLITE_BUSY"** as a buildable-now item.

`OpenStore` previously:
- opened SQLite with the default rollback journal and **no busy timeout** → the `depviz live` server reading while an hourly `sync` writes fails immediately with `SQLITE_BUSY`;
- set `foreign_keys` via a single `ExecContext`, which only reaches **one** connection in the pool (latent correctness bug — other pooled connections ran with FKs off).

## Fix

`storeDSN(path)` appends `_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)`. modernc.org/sqlite applies `_pragma` params on **every** new pooled connection, so:
- WAL lets readers and the single writer coexist;
- `busy_timeout` absorbs the remaining lock windows (retry instead of erroring);
- `foreign_keys` is now enforced on all connections, not just the first.

## Verification

- New `TestOpenStoreConcurrencyPragmas` asserts `journal_mode=wal`, `busy_timeout>=5000`, `foreign_keys=1` after `OpenStore`.
- `go test ./...` green; `go vet ./internal/core/` clean.
- End-to-end on the real board: `init` → `sync github 1789-tech/job-board` (105 cards) → `brief --workflow=board-status` produces the denoised "Pullable now" list; 5 concurrent `brief` runs against the same DB produce **zero** busy/locked errors (would fail pre-fix).

Board issue: https://github.com/1789-tech/job-board/issues/105
