### PR TITLE
feat: gate deployed instances + board-status JSON + post-deploy contract (BRIEF-112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ depviz edge add <from> <to> --kind blocked_by
 depviz query ready
 depviz query blockers
 depviz brief
+depviz brief --workflow=board-status [--format text|json]
 depviz gen html --board default --view graph --out dist/depviz.html
 depviz gen json --board default --out dist/depviz.json
 depviz live --addr 127.0.0.1:8686
@@ -193,6 +194,27 @@ When GitHub OAuth is configured, the daemon can create a local account, store
 the GitHub connection in `.depviz/state.db`, and issue an HTTP-only session
 cookie. The next backend slices can use that account connection for cached
 GitHub hydration and eventually write actions.
+
+### Gating a public instance
+
+Sessions only exist via GitHub OAuth, so an instance deployed on a public URL
+*without* an OAuth app has no gate at all: `/` and the board it renders are
+readable by anyone. Set `DEPVIZ_BASIC_AUTH` to require credentials on every
+route:
+
+```text
+DEPVIZ_BASIC_AUTH=user:password depviz server --addr 0.0.0.0:8766
+```
+
+`/api/health` deliberately stays open so deploy health checks keep working; it
+reports only booleans, never board data. Verify a deployment with:
+
+```text
+scripts/check-deploy.sh https://depviz.example
+```
+
+which asserts `/api/health` is `ok:true` *and* that `/` actually served the
+embedded Live app — a green health check alone does not prove the embed shipped.
 
 The Pages workflow publishes:
 

--- a/cmd/depviz/basicauth_test.go
+++ b/cmd/depviz/basicauth_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestParseBasicAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		user    string
+		pass    string
+		wantErr bool
+	}{
+		{name: "empty means no gate", raw: ""},
+		{name: "blank means no gate", raw: "   "},
+		{name: "user and password", raw: "demo:s3cret", user: "demo", pass: "s3cret"},
+		{name: "password may contain colons", raw: "demo:a:b:c", user: "demo", pass: "a:b:c"},
+		{name: "missing separator", raw: "demo", wantErr: true},
+		{name: "empty password", raw: "demo:", wantErr: true},
+		{name: "empty user", raw: ":s3cret", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, pass, err := parseBasicAuth(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseBasicAuth(%q) = nil error, want error", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBasicAuth(%q): %v", tt.raw, err)
+			}
+			if user != tt.user || pass != tt.pass {
+				t.Fatalf("parseBasicAuth(%q) = (%q, %q), want (%q, %q)", tt.raw, user, pass, tt.user, tt.pass)
+			}
+		})
+	}
+}

--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -202,6 +203,7 @@ func runBrief(ctx context.Context, dbPath string, args []string) error {
 	fs.SetOutput(os.Stderr)
 	board := fs.String("board", core.DefaultBoardID, "board id")
 	workflow := fs.String("workflow", "", "workflow mode (board-status)")
+	format := fs.String("format", "text", "output format (text, json)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -217,8 +219,19 @@ func runBrief(ctx context.Context, dbPath string, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := core.RenderBoardStatusBrief(os.Stdout, brief); err != nil {
-			return err
+		switch strings.TrimSpace(*format) {
+		case "", "text":
+			if err := core.RenderBoardStatusBrief(os.Stdout, brief); err != nil {
+				return err
+			}
+		case "json":
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(brief); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown brief format %q", *format)
 		}
 		return s.RecordBoardStatusHistogram(ctx, *board, brief.Statuses)
 	default:
@@ -439,9 +452,15 @@ func runServer(ctx context.Context, dbPath string, args []string) error {
 		return err
 	}
 	defer s.Close()
+	basicUser, basicPass, err := parseBasicAuth(os.Getenv("DEPVIZ_BASIC_AUTH"))
+	if err != nil {
+		return err
+	}
 	cfg := backend.Config{
 		Addr:                    *addr,
 		BaseURL:                 *baseURL,
+		BasicAuthUser:           basicUser,
+		BasicAuthPass:           basicPass,
 		GitHubClientID:          os.Getenv("DEPVIZ_GITHUB_CLIENT_ID"),
 		GitHubClientSecret:      os.Getenv("DEPVIZ_GITHUB_CLIENT_SECRET"),
 		GitHubAppID:             os.Getenv("DEPVIZ_GITHUB_APP_ID"),
@@ -452,6 +471,20 @@ func runServer(ctx context.Context, dbPath string, args []string) error {
 	srv := backend.NewServer(s, cfg)
 	fmt.Printf("serving DepViz backend at http://%s\n", *addr)
 	return http.ListenAndServe(*addr, srv.Handler())
+}
+
+// parseBasicAuth reads DEPVIZ_BASIC_AUTH as "user:password". Empty means no gate.
+// The password may contain ":"; the user may not.
+func parseBasicAuth(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", nil
+	}
+	user, pass, ok := strings.Cut(raw, ":")
+	if !ok || user == "" || pass == "" {
+		return "", "", errors.New(`DEPVIZ_BASIC_AUTH must look like "user:password"`)
+	}
+	return user, pass, nil
 }
 
 func envDefault(key, fallback string) string {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - DEPVIZ_DB=/data/state.db
       - DEPVIZ_ADDR=0.0.0.0:8766
       - DEPVIZ_BASE_URL=${DEPVIZ_BASE_URL:-https://depviz.1789.tech}
+      # Set to "user:password" to gate the instance. Without it, and without a
+      # GitHub OAuth app, a deployed instance is world-readable to anyone.
+      - DEPVIZ_BASIC_AUTH=${DEPVIZ_BASIC_AUTH:-}
       - DEPVIZ_GITHUB_CLIENT_ID=${DEPVIZ_GITHUB_CLIENT_ID:-}
       - DEPVIZ_GITHUB_CLIENT_SECRET=${DEPVIZ_GITHUB_CLIENT_SECRET:-}
       - DEPVIZ_GITHUB_WEBHOOK_SECRET=${DEPVIZ_GITHUB_WEBHOOK_SECRET:-}

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -135,6 +136,11 @@ type Config struct {
 	GitHubAppPrivateKeyFile string
 	GitHubWebhookSecret     string
 	SessionTTL              time.Duration
+	// BasicAuthUser/BasicAuthPass gate every route except /api/health when set.
+	// Without them a deployed instance is world-readable: sessions only exist via
+	// GitHub OAuth, so an instance with no OAuth app configured has no other gate.
+	BasicAuthUser string
+	BasicAuthPass string
 }
 
 type Server struct {
@@ -183,7 +189,31 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/auth/logout", s.handleLogout)
 	mux.HandleFunc("/api/workspaces", s.handleWorkspaces)
 	mux.Handle("/", http.FileServer(http.FS(live.AppFS())))
-	return mux
+	return s.withBasicAuth(mux)
+}
+
+// withBasicAuth gates the whole instance when BasicAuthUser/BasicAuthPass are set.
+// /api/health stays open so deploy health checks and the post-deploy contract keep
+// working; it reports only booleans, never board data.
+func (s *Server) withBasicAuth(next http.Handler) http.Handler {
+	if s.cfg.BasicAuthUser == "" && s.cfg.BasicAuthPass == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		user, pass, ok := r.BasicAuth()
+		userOK := subtle.ConstantTimeCompare([]byte(user), []byte(s.cfg.BasicAuthUser)) == 1
+		passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(s.cfg.BasicAuthPass)) == 1
+		if !ok || !userOK || !passOK {
+			w.Header().Set("WWW-Authenticate", `Basic realm="depviz", charset="UTF-8"`)
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "authentication required"})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/server_basicauth_test.go
+++ b/internal/backend/server_basicauth_test.go
@@ -1,0 +1,88 @@
+package backend
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"moul.io/depviz/v4/internal/core"
+)
+
+func newBasicAuthTestServer(t *testing.T, cfg Config) *httptest.Server {
+	t.Helper()
+	ctx := context.Background()
+	store, err := core.OpenStore(ctx, filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	cfg.Addr = "127.0.0.1:0"
+	cfg.BaseURL = "https://depviz.example"
+	ts := httptest.NewServer(NewServer(store, cfg).Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// get issues a request without following the redirect the SPA handler may emit.
+func get(t *testing.T, url, user, pass string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user != "" || pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = res.Body.Close() })
+	return res
+}
+
+func TestBasicAuthGate(t *testing.T) {
+	gated := Config{BasicAuthUser: "demo", BasicAuthPass: "s3cret"}
+
+	tests := []struct {
+		name       string
+		cfg        Config
+		path       string
+		user, pass string
+		want       int
+	}{
+		// Unset config must not change today's behavior.
+		{"unset config leaves SPA open", Config{}, "/", "", "", http.StatusOK},
+		{"unset config leaves health open", Config{}, "/api/health", "", "", http.StatusOK},
+
+		{"gated SPA rejects anonymous", gated, "/", "", "", http.StatusUnauthorized},
+		{"gated API rejects anonymous", gated, "/api/export", "", "", http.StatusUnauthorized},
+		{"gated rejects wrong password", gated, "/", "demo", "wrong", http.StatusUnauthorized},
+		{"gated rejects wrong user", gated, "/", "nope", "s3cret", http.StatusUnauthorized},
+		{"gated allows correct credentials", gated, "/", "demo", "s3cret", http.StatusOK},
+		// Health stays open so deploy checks keep working; it exposes no board data.
+		{"gated leaves health open", gated, "/api/health", "", "", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newBasicAuthTestServer(t, tt.cfg)
+			res := get(t, ts.URL+tt.path, tt.user, tt.pass)
+			if res.StatusCode != tt.want {
+				t.Fatalf("GET %s = %d, want %d", tt.path, res.StatusCode, tt.want)
+			}
+		})
+	}
+}
+
+// A 401 without WWW-Authenticate makes browsers show a blank error instead of a
+// login prompt, which would make a gated instance look broken.
+func TestBasicAuthChallengeHeader(t *testing.T) {
+	ts := newBasicAuthTestServer(t, Config{BasicAuthUser: "demo", BasicAuthPass: "s3cret"})
+	res := get(t, ts.URL+"/", "", "")
+	if got := res.Header.Get("WWW-Authenticate"); got == "" {
+		t.Fatal("gated 401 must send a WWW-Authenticate challenge, got none")
+	}
+}

--- a/scripts/check-deploy.sh
+++ b/scripts/check-deploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Post-deploy contract for a depviz server (BRIEF-112).
+#
+# A green /api/health only proves the process is up. It says nothing about whether
+# the embedded Live SPA actually embedded, so this also fetches / and asserts the
+# app really shipped. Health-green + /-broken is the failure this exists to catch.
+#
+# Usage: scripts/check-deploy.sh [base-url]
+#   BASE_URL           default https://depviz.1789.tech
+#   DEPVIZ_BASIC_AUTH  "user:password" if the instance is gated (see README)
+set -euo pipefail
+
+BASE_URL="${1:-${BASE_URL:-https://depviz.1789.tech}}"
+BASE_URL="${BASE_URL%/}"
+CURL=(curl --silent --show-error --max-time 20)
+if [[ -n "${DEPVIZ_BASIC_AUTH:-}" ]]; then
+  CURL+=(--user "${DEPVIZ_BASIC_AUTH}")
+fi
+
+fail() { printf '  FAIL: %s\n' "$1" >&2; exit 1; }
+
+printf 'checking %s\n' "${BASE_URL}"
+
+# 1. health reports ok:true (never gated, so this works on a gated instance too)
+health="$("${CURL[@]}" "${BASE_URL}/api/health")" || fail "/api/health unreachable"
+case "${health}" in
+  *'"ok":true'*) printf '  ok: /api/health reports ok:true\n' ;;
+  *) fail "/api/health did not report ok:true: ${health}" ;;
+esac
+
+# 2. / serves the SPA. Separate the status code from the body so a 401 on a gated
+#    instance is reported as "credentials needed", not as a missing embed.
+root_body="$("${CURL[@]}" --write-out '\n%{http_code}' "${BASE_URL}/")" || fail "/ unreachable"
+root_code="${root_body##*$'\n'}"
+root_html="${root_body%$'\n'*}"
+if [[ "${root_code}" == "401" ]]; then
+  fail "/ returned 401 — instance is gated, set DEPVIZ_BASIC_AUTH to check it"
+fi
+[[ "${root_code}" == "200" ]] || fail "/ returned ${root_code}, want 200"
+printf '  ok: / returned 200\n'
+
+# 3. the response is really the Live app, not a stray index or an error page.
+#    This is the "embed didn't embed" check: the binary serves live/app via go:embed.
+case "${root_html}" in
+  *'app.js'*) printf '  ok: / served the embedded Live SPA\n' ;;
+  *) fail "/ returned 200 but no app.js reference — the embedded Live FS did not embed" ;;
+esac
+
+# 4. the SPA's own assets resolve, which a partial embed would break.
+for asset in app.js style.css; do
+  code="$("${CURL[@]}" --output /dev/null --write-out '%{http_code}' "${BASE_URL}/${asset}")" || fail "/${asset} unreachable"
+  [[ "${code}" == "200" ]] || fail "/${asset} returned ${code}, want 200"
+  printf '  ok: /%s returned 200\n' "${asset}"
+done
+
+# NOTE: the brief's fourth assertion — "the demo board renders >=1 card" — is not
+# checked yet: there is no demo board to render. It is blocked on the access
+# decision in BRIEF-112 and lands with that slice.
+
+printf 'post-deploy contract passed\n'


### PR DESCRIPTION
Brief: https://github.com/1789-tech/job-board/issues/112

The brief asks the deployed instance to answer "what can move now?" cold, on the 1789 board. Building that surfaced a blocker the brief did not account for, so this PR lands the parts that are correct under every resolution and leaves the demo board itself for the follow-up slice.

## The blocker

`1789-tech/job-board` is a **private** repo. `depviz.1789.tech` is **world-open** — verified: `/` and `/api/health` both answer 200 anonymously. Sessions only exist via GitHub OAuth (`accountForRequest` -> `web_sessions`, written by the OAuth callback), and the live instance reports `github_oauth_configured:false`. So **no account can exist there**, every authenticated route is unreachable, and the only surface a visitor can reach is the anonymous one.

That makes "OAuth is out of scope" load-bearing rather than incidental: rendering the private board on that URL today would publish it. The demo board waits on the access decision in the brief.

## What is in here

**1. An access gate that does not need an OAuth app** — `DEPVIZ_BASIC_AUTH=user:password` gates every route. Off when unset, so no behavior change to any existing deployment. `/api/health` stays open so deploy health checks keep working; it reports only booleans, never board data. Constant-time credential compare, and a `WWW-Authenticate` challenge so browsers prompt instead of showing a blank error.

**2. `depviz brief --workflow=board-status --format=json`** — the `BoardStatusBrief` struct was already fully JSON-tagged but nothing ever marshalled it. Any demo payload has to be generated from somewhere; this is that seam, and it stays CLI-side, so it adds no network surface. `--format=text` remains the default; an unknown format is rejected rather than silently ignored.

**3. `scripts/check-deploy.sh`** — the brief's slice 4. Asserts `/api/health` is `ok:true` **and** that `/` really served the embedded Live SPA, which is the "health green but the embed did not embed" case the brief called out. Also checks the SPA's own assets resolve, and reports a gated 401 as "set DEPVIZ_BASIC_AUTH" rather than as a broken deploy.

The brief's fourth assertion — "the demo board renders >=1 card" — is deliberately not stubbed: there is no demo board yet. It lands with that slice.

## Verification

- `go test ./...` green; `gofmt` clean.
- Table-driven tests for the gate (anonymous, wrong user, wrong password, correct creds, health-stays-open, and unset-config-changes-nothing) and for `DEPVIZ_BASIC_AUTH` parsing.
- Ran the real dogfood end-to-end: synced 115 cards from `1789-tech/job-board`, served them from a local gated server, and confirmed anonymous `/` -> 401, good creds -> 200, `/api/health` -> 200 while gated.
- `scripts/check-deploy.sh` passes against the live `https://depviz.1789.tech` today, and correctly fails the gated local instance without credentials.
- `--format=json` verified on the real board: pullable `[#107, #111, #113]`, matching the text render.

No 1789 data is added to this public repo.