### PR TITLE
fix: cold open renders the sample board instead of an empty stateful canvas (BRIEF-112)

### DIFF
--- a/live/app/app.js
+++ b/live/app/app.js
@@ -173,7 +173,10 @@ async function boot() {
     return;
   }
   await refreshBackendSession();
-  if (state.backendSession.available) {
+  // Every board route answers 401 until authenticated, so an available-but-
+  // anonymous backend can only render an empty stateful canvas. Fall through
+  // to the sample instead: without an OAuth app configured, nobody can sign in.
+  if (state.backendSession.available && state.backendSession.authenticated) {
     await setMode('stateful', { renderNow: true });
     return;
   }


### PR DESCRIPTION
Opening https://depviz.1789.tech/app/ cold today shows **"GitHub OAuth is not configured"** and an empty canvas — to every visitor. This is the BRIEF-112 DoD blocker ("à froid, l'app s'ouvre vide").

## Root cause

`boot()` entered stateful mode whenever a backend *existed*, not when it could actually *read* a board:

```js
await refreshBackendSession();
if (state.backendSession.available) {      // ← true even when anonymous
  await setMode(stateful, { renderNow: true });
  return;                                  // ← loadSample() becomes dead code
}
setMode(stateless, { renderNow: false });
loadSample();
```

On the deployed instance:
- `/api/session` → `200 {"authenticated":false,"github_oauth_configured":false}` → `available: true`
- so we take the stateful branch and return early — `loadSample()` never runs
- stateful then fetches `/api/export` → `401 {"error":"authentication required"}` → nothing renders

Because no GitHub OAuth app is configured (and it is explicitly out of scope for BRIEF-112), **no visitor can ever authenticate** — so the instance is permanently empty at cold open. The sample fallback has been unreachable in production the whole time.

## Fix

Enter stateful only when the session can actually read a board (`available && authenticated`); otherwise fall through to stateless + `loadSample()`. One condition, no new deps, no OAuth needed, no private data.

## Verification

Driven with a real headless browser against a local server reproducing prod exactly (`session` 200 anonymous, `export` 401). Prod is the control, so a green result proves something:

| | `#boardTitle` | `#boardMeta` | verdict |
|---|---|---|---|
| prod (this code, live now) | `Stateful DepViz` | `Backend is running, but GitHub OAuth is not configured yet.` | FAIL — empty |
| this PR (local) | `DepViz v4 POC` | `4 nodes - 4 edges` | PASS — real board |

The fixed cold open renders the bundled sample board: NODES 4 · READY 2 · BLOCKED 2 · LOCAL 1, with the dependency clusters painted — i.e. it answers "what can move now?" with no user action.

`go vet ./...` clean, `go test ./...` green (4/4 packages).

## Scope note

This makes the app *show something honest* cold. It does **not** make the instance show the real 1789 board — see the BRIEF-112 comment for why that half of the DoD is not satisfiable as written (the only label-driven board we have is private).