### PR TITLE
feat: load private demo board behind auth (BRIEF-112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,32 @@ DEPVIZ_BASIC_AUTH=user:password depviz server --addr 0.0.0.0:8766
 ```
 
 `/api/health` deliberately stays open so deploy health checks keep working; it
-reports only booleans, never board data. Verify a deployment with:
+reports only booleans, never board data. The public landing page at `/` also
+stays open; `/app/` and private API routes require Basic Auth when the gate is
+configured.
+
+For the 1789 dogfood instance, a private Hermes `board-snapshot.json` can be
+pushed into the server and rendered at cold open for authenticated users:
+
+```text
+DEPVIZ_BASIC_AUTH=user:password
+DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE=/data/board-snapshot.json
+DEPVIZ_DEMO_BOARD_MAX_AGE=90m
+```
+
+`GET /api/demo-board` returns that board-status payload only after Basic Auth.
+`PUT /api/demo-board` uses the same Basic Auth gate and atomically replaces the
+configured snapshot file; anonymous writes never create or change the file.
+
+Verify a deployment with:
 
 ```text
 scripts/check-deploy.sh https://depviz.example
 ```
 
-which asserts `/api/health` is `ok:true` *and* that `/` actually served the
-embedded Live app — a green health check alone does not prove the embed shipped.
+which asserts `/api/health` is `ok:true`, `/` serves the landing page, `/app/`
+serves the embedded Live app, and the private demo-board endpoint does not
+degrade into a public empty 200.
 
 The Pages workflow publishes:
 

--- a/cmd/depviz/basicauth_test.go
+++ b/cmd/depviz/basicauth_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestParseBasicAuth(t *testing.T) {
 	tests := []struct {
@@ -35,5 +38,21 @@ func TestParseBasicAuth(t *testing.T) {
 				t.Fatalf("parseBasicAuth(%q) = (%q, %q), want (%q, %q)", tt.raw, user, pass, tt.user, tt.pass)
 			}
 		})
+	}
+}
+
+func TestParseOptionalDuration(t *testing.T) {
+	d, err := parseOptionalDuration("45m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != 45*time.Minute {
+		t.Fatalf("duration = %s, want 45m", d)
+	}
+	if d, err := parseOptionalDuration(" "); err != nil || d != 0 {
+		t.Fatalf("blank duration = %s, %v; want zero nil", d, err)
+	}
+	if _, err := parseOptionalDuration("soon"); err == nil {
+		t.Fatal("invalid duration returned nil error")
 	}
 }

--- a/cmd/depviz/main.go
+++ b/cmd/depviz/main.go
@@ -456,11 +456,17 @@ func runServer(ctx context.Context, dbPath string, args []string) error {
 	if err != nil {
 		return err
 	}
+	demoBoardMaxAge, err := parseOptionalDuration(os.Getenv("DEPVIZ_DEMO_BOARD_MAX_AGE"))
+	if err != nil {
+		return err
+	}
 	cfg := backend.Config{
 		Addr:                    *addr,
 		BaseURL:                 *baseURL,
 		BasicAuthUser:           basicUser,
 		BasicAuthPass:           basicPass,
+		DemoBoardSnapshotFile:   os.Getenv("DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE"),
+		DemoBoardMaxAge:         demoBoardMaxAge,
 		GitHubClientID:          os.Getenv("DEPVIZ_GITHUB_CLIENT_ID"),
 		GitHubClientSecret:      os.Getenv("DEPVIZ_GITHUB_CLIENT_SECRET"),
 		GitHubAppID:             os.Getenv("DEPVIZ_GITHUB_APP_ID"),
@@ -485,6 +491,18 @@ func parseBasicAuth(raw string) (string, string, error) {
 		return "", "", errors.New(`DEPVIZ_BASIC_AUTH must look like "user:password"`)
 	}
 	return user, pass, nil
+}
+
+func parseOptionalDuration(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("DEPVIZ_DEMO_BOARD_MAX_AGE must be a Go duration like 30m: %w", err)
+	}
+	return d, nil
 }
 
 func envDefault(key, fallback string) string {
@@ -517,6 +535,10 @@ Environment:
   DEPVIZ_DB                    override .depviz/state.db
   DEPVIZ_ADDR                  default server listen address
   DEPVIZ_BASE_URL              public server URL for OAuth callbacks
+  DEPVIZ_BASIC_AUTH            optional "user:password" gate for /app and private APIs
+  DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE
+                               private hermes board-snapshot.json served after basic auth
+  DEPVIZ_DEMO_BOARD_MAX_AGE    stale threshold for demo snapshot, default 30m
   DEPVIZ_GITHUB_CLIENT_ID      GitHub OAuth app client id
   DEPVIZ_GITHUB_CLIENT_SECRET  GitHub OAuth app client secret
   DEPVIZ_GITHUB_APP_ID         GitHub App id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       # Set to "user:password" to gate the instance. Without it, and without a
       # GitHub OAuth app, a deployed instance is world-readable to anyone.
       - DEPVIZ_BASIC_AUTH=${DEPVIZ_BASIC_AUTH:-}
+      - DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE=${DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE:-/data/board-snapshot.json}
+      - DEPVIZ_DEMO_BOARD_MAX_AGE=${DEPVIZ_DEMO_BOARD_MAX_AGE:-90m}
       - DEPVIZ_GITHUB_CLIENT_ID=${DEPVIZ_GITHUB_CLIENT_ID:-}
       - DEPVIZ_GITHUB_CLIENT_SECRET=${DEPVIZ_GITHUB_CLIENT_SECRET:-}
       - DEPVIZ_GITHUB_WEBHOOK_SECRET=${DEPVIZ_GITHUB_WEBHOOK_SECRET:-}

--- a/internal/backend/demo_board.go
+++ b/internal/backend/demo_board.go
@@ -1,0 +1,208 @@
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"moul.io/depviz/v4/internal/core"
+)
+
+const defaultDemoBoardMaxAge = 30 * time.Minute
+
+type demoBoardPayload struct {
+	Snapshot            core.Snapshot          `json:"snapshot"`
+	Brief               core.BoardStatusBrief  `json:"brief"`
+	BriefType           string                 `json:"brief_type"`
+	SnapshotGeneratedAt string                 `json:"snapshot_generated_at"`
+	SnapshotStale       bool                   `json:"snapshot_stale"`
+	SnapshotAgeSec      int                    `json:"snapshot_age_sec,omitempty"`
+	Warnings            []string               `json:"warnings,omitempty"`
+}
+
+type hermesBoardSnapshot struct {
+	GeneratedAt string             `json:"generated_at"`
+	Queue       []hermesBoardIssue `json:"queue"`
+	Open        []hermesBoardIssue `json:"open"`
+	Done        []hermesBoardIssue `json:"done"`
+}
+
+type hermesBoardIssue struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Project string `json:"project"`
+	Status  string `json:"status"`
+	Prio    string `json:"prio"`
+	Type    string `json:"type"`
+	Rank    int    `json:"rank"`
+}
+
+func (s *Server) demoBoardConfigured() bool {
+	return strings.TrimSpace(s.cfg.DemoBoardSnapshotFile) != ""
+}
+
+func (s *Server) handleDemoBoard(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !s.demoBoardConfigured() {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "demo board not configured"})
+		return
+	}
+	if !s.basicAuthAuthorized(r) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "demo board requires basic auth"})
+		return
+	}
+	payload, err := s.loadDemoBoard()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) loadDemoBoard() (demoBoardPayload, error) {
+	f, err := os.Open(s.cfg.DemoBoardSnapshotFile)
+	if err != nil {
+		return demoBoardPayload{}, fmt.Errorf("open demo board snapshot: %w", err)
+	}
+	defer f.Close()
+	return parseDemoBoard(f, s.demoBoardMaxAge())
+}
+
+func (s *Server) demoBoardMaxAge() time.Duration {
+	if s.cfg.DemoBoardMaxAge > 0 {
+		return s.cfg.DemoBoardMaxAge
+	}
+	return defaultDemoBoardMaxAge
+}
+
+func parseDemoBoard(r io.Reader, maxAge time.Duration) (demoBoardPayload, error) {
+	var hermes hermesBoardSnapshot
+	if err := json.NewDecoder(r).Decode(&hermes); err != nil {
+		return demoBoardPayload{}, fmt.Errorf("parse demo board snapshot: %w", err)
+	}
+	generatedAt, err := time.Parse(time.RFC3339, hermes.GeneratedAt)
+	if err != nil {
+		return demoBoardPayload{}, fmt.Errorf("parse generated_at: %w", err)
+	}
+	snap := hermes.toDepVizSnapshot(generatedAt)
+	brief := core.BuildBoardStatusBriefFromSnapshot(snap, nil)
+	age := time.Since(generatedAt)
+	stale := maxAge > 0 && age > maxAge
+	warnings := append([]string{}, brief.Warnings...)
+	if stale {
+		msg := fmt.Sprintf("snapshot stale: generated %s", generatedAt.UTC().Format(time.RFC3339))
+		warnings = append(warnings, msg)
+		brief.Warnings = append(brief.Warnings, msg)
+		brief.SnapshotCheck = &core.SnapshotFreshness{
+			Checked:        true,
+			Disagreement:   false,
+			Message:        msg,
+			SnapshotAgeSec: int(age.Seconds()),
+		}
+	}
+	return demoBoardPayload{
+		Snapshot:            snap,
+		Brief:               brief,
+		BriefType:           "board-status",
+		SnapshotGeneratedAt: generatedAt.UTC().Format(time.RFC3339),
+		SnapshotStale:       stale,
+		SnapshotAgeSec:      int(age.Seconds()),
+		Warnings:            warnings,
+	}, nil
+}
+
+func (h hermesBoardSnapshot) toDepVizSnapshot(generatedAt time.Time) core.Snapshot {
+	issues := map[int]hermesBoardIssue{}
+	for _, rows := range [][]hermesBoardIssue{h.Open, h.Done, h.Queue} {
+		for _, issue := range rows {
+			if issue.Number == 0 {
+				continue
+			}
+			issues[issue.Number] = issue
+		}
+	}
+	numbers := make([]int, 0, len(issues))
+	for n := range issues {
+		numbers = append(numbers, n)
+	}
+	sort.Ints(numbers)
+	nodes := make([]core.Node, 0, len(numbers))
+	for _, number := range numbers {
+		nodes = append(nodes, hermesIssueToNode(issues[number], generatedAt))
+	}
+	return core.Snapshot{
+		Board: core.Board{
+			ID:          "1789-job-board",
+			Name:        "1789 job-board",
+			Description: "Private 1789 delegation board snapshot",
+			ScopeQuery:  "repo:1789-tech/job-board",
+			UpdatedAt:   generatedAt,
+			Metrics: &core.BoardMetrics{
+				Items:      len(nodes),
+				Open:       countOpen(nodes),
+				Closed:     len(nodes) - countOpen(nodes),
+				External:   len(nodes),
+				LastSyncAt: generatedAt,
+				SyncStatus: "snapshot",
+			},
+		},
+		Nodes: nodes,
+		Edges: nil,
+	}
+}
+
+func hermesIssueToNode(issue hermesBoardIssue, generatedAt time.Time) core.Node {
+	status := strings.TrimPrefix(issue.Status, "status:")
+	state := status
+	if state == "" {
+		state = "open"
+	}
+	labels := []string{}
+	addLabel := func(prefix, value string) {
+		value = strings.TrimSpace(strings.TrimPrefix(value, prefix))
+		if value != "" {
+			labels = append(labels, prefix+value)
+		}
+	}
+	addLabel("status:", status)
+	addLabel("project:", issue.Project)
+	addLabel("prio:", issue.Prio)
+	addLabel("type:", issue.Type)
+	data, _ := json.Marshal(map[string]any{
+		"repo":   "1789-tech/job-board",
+		"number": issue.Number,
+		"labels": labels,
+		"rank":   issue.Rank,
+	})
+	return core.Node{
+		ID:         fmt.Sprintf("gh:1789-tech/job-board#%d", issue.Number),
+		Kind:       "issue",
+		Title:      issue.Title,
+		State:      state,
+		DataJSON:   string(data),
+		UpdatedAt:  generatedAt,
+		URL:        issue.URL,
+		SourceID:   "github:1789-tech/job-board",
+		ExternalID: fmt.Sprintf("#%d", issue.Number),
+	}
+}
+
+func countOpen(nodes []core.Node) int {
+	open := 0
+	for _, n := range nodes {
+		if !n.IsClosed() {
+			open++
+		}
+	}
+	return open
+}

--- a/internal/backend/demo_board.go
+++ b/internal/backend/demo_board.go
@@ -1,11 +1,13 @@
 package backend
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -16,13 +18,13 @@ import (
 const defaultDemoBoardMaxAge = 30 * time.Minute
 
 type demoBoardPayload struct {
-	Snapshot            core.Snapshot          `json:"snapshot"`
-	Brief               core.BoardStatusBrief  `json:"brief"`
-	BriefType           string                 `json:"brief_type"`
-	SnapshotGeneratedAt string                 `json:"snapshot_generated_at"`
-	SnapshotStale       bool                   `json:"snapshot_stale"`
-	SnapshotAgeSec      int                    `json:"snapshot_age_sec,omitempty"`
-	Warnings            []string               `json:"warnings,omitempty"`
+	Snapshot            core.Snapshot         `json:"snapshot"`
+	Brief               core.BoardStatusBrief `json:"brief"`
+	BriefType           string                `json:"brief_type"`
+	SnapshotGeneratedAt string                `json:"snapshot_generated_at"`
+	SnapshotStale       bool                  `json:"snapshot_stale"`
+	SnapshotAgeSec      int                   `json:"snapshot_age_sec,omitempty"`
+	Warnings            []string              `json:"warnings,omitempty"`
 }
 
 type hermesBoardSnapshot struct {
@@ -48,8 +50,8 @@ func (s *Server) demoBoardConfigured() bool {
 }
 
 func (s *Server) handleDemoBoard(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
+	if r.Method != http.MethodGet && r.Method != http.MethodPut {
+		w.Header().Set("Allow", "GET, PUT")
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
@@ -61,12 +63,33 @@ func (s *Server) handleDemoBoard(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "demo board requires basic auth"})
 		return
 	}
+	if r.Method == http.MethodPut {
+		s.handleDemoBoardPut(w, r)
+		return
+	}
 	payload, err := s.loadDemoBoard()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) handleDemoBoardPut(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read demo board snapshot: " + err.Error()})
+		return
+	}
+	if _, err := parseDemoBoard(bytes.NewReader(body), s.demoBoardMaxAge()); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := writeDemoBoardSnapshotFile(s.cfg.DemoBoardSnapshotFile, body); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
 func (s *Server) loadDemoBoard() (demoBoardPayload, error) {
@@ -76,6 +99,34 @@ func (s *Server) loadDemoBoard() (demoBoardPayload, error) {
 	}
 	defer f.Close()
 	return parseDemoBoard(f, s.demoBoardMaxAge())
+}
+
+func writeDemoBoardSnapshotFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create demo board snapshot directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".board-snapshot-*.json")
+	if err != nil {
+		return fmt.Errorf("create demo board snapshot temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write demo board snapshot temp file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod demo board snapshot temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close demo board snapshot temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace demo board snapshot: %w", err)
+	}
+	return nil
 }
 
 func (s *Server) demoBoardMaxAge() time.Duration {

--- a/internal/backend/demo_board_test.go
+++ b/internal/backend/demo_board_test.go
@@ -2,9 +2,11 @@ package backend
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -76,24 +78,89 @@ func TestDemoBoardMarksStaleSnapshots(t *testing.T) {
 	}
 }
 
+func TestDemoBoardPutRequiresBasicAuthAndDoesNotWriteAnonymously(t *testing.T) {
+	snapshot := writeDemoSnapshot(t, time.Now().UTC())
+	before, err := os.ReadFile(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := newBasicAuthTestServer(t, Config{
+		BasicAuthUser:         "demo",
+		BasicAuthPass:         "s3cret",
+		DemoBoardSnapshotFile: snapshot,
+	})
+
+	res := put(t, ts.URL+"/api/demo-board", "", "", demoSnapshotJSON(time.Now().UTC(), 220, "Anonymous write"))
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("anonymous PUT status = %d, want %d", res.StatusCode, http.StatusUnauthorized)
+	}
+	after, err := os.ReadFile(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("anonymous PUT changed the demo board snapshot")
+	}
+}
+
+func TestDemoBoardPutReplacesSnapshot(t *testing.T) {
+	snapshot := writeDemoSnapshot(t, time.Now().UTC())
+	ts := newBasicAuthTestServer(t, Config{
+		BasicAuthUser:         "demo",
+		BasicAuthPass:         "s3cret",
+		DemoBoardSnapshotFile: snapshot,
+	})
+
+	res := put(t, ts.URL+"/api/demo-board", "demo", "s3cret", demoSnapshotJSON(time.Now().UTC(), 220, "Updated private brief"))
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("authenticated PUT status = %d, want %d: %s", res.StatusCode, http.StatusOK, body)
+	}
+
+	res = get(t, ts.URL+"/api/demo-board", "demo", "s3cret")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET after PUT status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	var payload demoBoardPayload
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, node := range payload.Snapshot.Nodes {
+		if node.ExternalID == "#220" && node.State == "ready" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("snapshot nodes after PUT = %+v", payload.Snapshot.Nodes)
+	}
+	if payload.Brief.Counts.Pullable != 1 {
+		t.Fatalf("pullable after PUT = %d, want 1", payload.Brief.Counts.Pullable)
+	}
+}
+
 func writeDemoSnapshot(t *testing.T, generatedAt time.Time) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "board-snapshot.json")
-	data := `{
+	if err := os.WriteFile(path, []byte(demoSnapshotJSON(generatedAt, 112, "Ready private brief")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func demoSnapshotJSON(generatedAt time.Time, number int, title string) string {
+	return `{
   "generated_at": "` + generatedAt.Format(time.RFC3339) + `",
   "queue": [
-    {"number": 112, "title": "Ready private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1}
+    {"number": ` + strconv.Itoa(number) + `, "title": "` + title + `", "url": "https://github.com/1789-tech/job-board/issues/` + strconv.Itoa(number) + `", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1}
   ],
   "open": [
-    {"number": 112, "title": "Ready private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1},
+    {"number": ` + strconv.Itoa(number) + `, "title": "` + title + `", "url": "https://github.com/1789-tech/job-board/issues/` + strconv.Itoa(number) + `", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1},
     {"number": 113, "title": "Blocked private brief", "url": "https://github.com/1789-tech/job-board/issues/113", "project": "boussole", "status": "blocked", "prio": "normal", "type": "brief", "rank": 2}
   ],
   "done": [
     {"number": 90, "title": "Done private brief", "url": "https://github.com/1789-tech/job-board/issues/90", "project": "career", "status": "done", "prio": "normal", "type": "build", "rank": 3}
   ]
 }`
-	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return path
 }

--- a/internal/backend/demo_board_test.go
+++ b/internal/backend/demo_board_test.go
@@ -1,0 +1,99 @@
+package backend
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDemoBoardRequiresBasicAuth(t *testing.T) {
+	snapshot := writeDemoSnapshot(t, time.Now().UTC())
+	ts := newBasicAuthTestServer(t, Config{
+		BasicAuthUser:         "demo",
+		BasicAuthPass:         "s3cret",
+		DemoBoardSnapshotFile: snapshot,
+	})
+
+	res := get(t, ts.URL+"/api/demo-board", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("anonymous status = %d, want %d", res.StatusCode, http.StatusUnauthorized)
+	}
+
+	res = get(t, ts.URL+"/api/demo-board", "demo", "s3cret")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	var payload demoBoardPayload
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.BriefType != "board-status" {
+		t.Fatalf("brief_type = %q, want board-status", payload.BriefType)
+	}
+	if payload.Brief.Counts.Pullable != 1 {
+		t.Fatalf("pullable = %d, want 1", payload.Brief.Counts.Pullable)
+	}
+	if payload.Snapshot.Board.ScopeQuery != "repo:1789-tech/job-board" {
+		t.Fatalf("scope = %q", payload.Snapshot.Board.ScopeQuery)
+	}
+}
+
+func TestDemoBoardNotServedWithoutBasicAuthGate(t *testing.T) {
+	snapshot := writeDemoSnapshot(t, time.Now().UTC())
+	ts := newBasicAuthTestServer(t, Config{DemoBoardSnapshotFile: snapshot})
+
+	res := get(t, ts.URL+"/api/demo-board", "", "")
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", res.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestDemoBoardMarksStaleSnapshots(t *testing.T) {
+	snapshot := writeDemoSnapshot(t, time.Now().UTC().Add(-2*time.Hour))
+	ts := newBasicAuthTestServer(t, Config{
+		BasicAuthUser:         "demo",
+		BasicAuthPass:         "s3cret",
+		DemoBoardSnapshotFile: snapshot,
+		DemoBoardMaxAge:       time.Minute,
+	})
+
+	res := get(t, ts.URL+"/api/demo-board", "demo", "s3cret")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	var payload demoBoardPayload
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.SnapshotStale {
+		t.Fatal("snapshot_stale = false, want true")
+	}
+	if payload.Brief.SnapshotCheck == nil || payload.Brief.SnapshotCheck.SnapshotAgeSec == 0 {
+		t.Fatalf("snapshot check missing age: %+v", payload.Brief.SnapshotCheck)
+	}
+}
+
+func writeDemoSnapshot(t *testing.T, generatedAt time.Time) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "board-snapshot.json")
+	data := `{
+  "generated_at": "` + generatedAt.Format(time.RFC3339) + `",
+  "queue": [
+    {"number": 112, "title": "Ready private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1}
+  ],
+  "open": [
+    {"number": 112, "title": "Ready private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 1},
+    {"number": 113, "title": "Blocked private brief", "url": "https://github.com/1789-tech/job-board/issues/113", "project": "boussole", "status": "blocked", "prio": "normal", "type": "brief", "rank": 2}
+  ],
+  "done": [
+    {"number": 90, "title": "Done private brief", "url": "https://github.com/1789-tech/job-board/issues/90", "project": "career", "status": "done", "prio": "normal", "type": "build", "rank": 3}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -141,6 +141,10 @@ type Config struct {
 	// GitHub OAuth, so an instance with no OAuth app configured has no other gate.
 	BasicAuthUser string
 	BasicAuthPass string
+	// DemoBoardSnapshotFile points at a private hermes board-snapshot.json file.
+	// It is only served to requests that passed Basic Auth.
+	DemoBoardSnapshotFile string
+	DemoBoardMaxAge       time.Duration
 }
 
 type Server struct {
@@ -167,6 +171,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/health", s.handleHealth)
 	mux.HandleFunc("/api/session", s.handleSession)
 	mux.HandleFunc("/api/export", s.handleExport)
+	mux.HandleFunc("/api/demo-board", s.handleDemoBoard)
 	mux.HandleFunc("/api/boards", s.handleBoards)
 	mux.HandleFunc("/api/board-items", s.handleBoardItems)
 	mux.HandleFunc("/api/board-links", s.handleBoardLinks)
@@ -217,16 +222,30 @@ func (s *Server) withBasicAuth(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		user, pass, ok := r.BasicAuth()
-		userOK := subtle.ConstantTimeCompare([]byte(user), []byte(s.cfg.BasicAuthUser)) == 1
-		passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(s.cfg.BasicAuthPass)) == 1
-		if !ok || !userOK || !passOK {
+		if !s.basicAuthAuthorized(r) {
 			w.Header().Set("WWW-Authenticate", `Basic realm="depviz", charset="UTF-8"`)
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "authentication required"})
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func (s *Server) basicAuthConfigured() bool {
+	return s.cfg.BasicAuthUser != "" || s.cfg.BasicAuthPass != ""
+}
+
+func (s *Server) basicAuthAuthorized(r *http.Request) bool {
+	if !s.basicAuthConfigured() {
+		return false
+	}
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		return false
+	}
+	userOK := subtle.ConstantTimeCompare([]byte(user), []byte(s.cfg.BasicAuthUser)) == 1
+	passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(s.cfg.BasicAuthPass)) == 1
+	return userOK && passOK
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -335,6 +354,8 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	out := map[string]any{
 		"authenticated":             ok,
+		"basic_authenticated":       s.basicAuthAuthorized(r),
+		"demo_board_available":      s.demoBoardConfigured() && s.basicAuthAuthorized(r),
 		"github_oauth_configured":   s.githubOAuthConfigured(),
 		"github_app_configured":     s.githubAppConfigured(),
 		"github_webhook_configured": s.githubWebhookConfigured(),

--- a/internal/backend/server_basicauth_test.go
+++ b/internal/backend/server_basicauth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"moul.io/depviz/v4/internal/core"
@@ -32,6 +33,24 @@ func get(t *testing.T, url, user, pass string) *http.Response {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if user != "" || pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = res.Body.Close() })
+	return res
+}
+
+func put(t *testing.T, url, user, pass, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
 	if user != "" || pass != "" {
 		req.SetBasicAuth(user, pass)
 	}

--- a/internal/core/board_status.go
+++ b/internal/core/board_status.go
@@ -61,6 +61,18 @@ func (s *Store) BuildBoardStatusBrief(ctx context.Context, boardID string) (Boar
 	if err != nil {
 		return BoardStatusBrief{}, err
 	}
+	b := BuildBoardStatusBriefFromSnapshot(snap, s.lastBoardStatusCounts(ctx, boardID))
+	if repo := boardStatusRepo(snap.Nodes); repo == "1789-tech/job-board" {
+		check := checkBoardSnapshot(ctx, repo, b.Pullable)
+		b.SnapshotCheck = &check
+		if check.Disagreement {
+			b.Warnings = append(b.Warnings, check.Message)
+		}
+	}
+	return b, nil
+}
+
+func BuildBoardStatusBriefFromSnapshot(snap Snapshot, previous map[string]int) BoardStatusBrief {
 	nodes := map[string]Node{}
 	for _, n := range snap.Nodes {
 		nodes[n.ID] = n
@@ -112,19 +124,12 @@ func (s *Store) BuildBoardStatusBrief(ctx context.Context, boardID string) (Boar
 			DroppedEdge: droppedEdges,
 		},
 		Statuses:  statuses,
-		Deltas:    deltas(statuses, s.lastBoardStatusCounts(ctx, boardID)),
+		Deltas:    deltas(statuses, previous),
 		Pullable:  limitItems(pullable, 12),
 		Blocked:   limitItems(blocked, 12),
 		Untriaged: limitItems(untriaged, 12),
 	}
-	if repo := boardStatusRepo(snap.Nodes); repo == "1789-tech/job-board" {
-		check := checkBoardSnapshot(ctx, repo, pullable)
-		b.SnapshotCheck = &check
-		if check.Disagreement {
-			b.Warnings = append(b.Warnings, check.Message)
-		}
-	}
-	return b, nil
+	return b
 }
 
 func RenderBoardStatusBrief(w io.Writer, b BoardStatusBrief) error {

--- a/live/app/app.js
+++ b/live/app/app.js
@@ -89,7 +89,8 @@ const state = {
   showClosed: true,
   githubRefresh: [],
   githubFailures: [],
-  backendSession: { available: false, authenticated: false, github_oauth_configured: false, github_app_configured: false },
+  backendSession: { available: false, authenticated: false, basic_authenticated: false, demo_board_available: false, github_oauth_configured: false, github_app_configured: false },
+  demoBoardMeta: null,
   userPanelOpen: false,
   workspaceTab: 'views',
   currentBoardID: 'default',
@@ -173,6 +174,11 @@ async function boot() {
     return;
   }
   await refreshBackendSession();
+  if (state.backendSession.available && state.backendSession.basic_authenticated && state.backendSession.demo_board_available) {
+    setMode('stateless', { renderNow: false });
+    await loadDemoBoard();
+    return;
+  }
   // Every board route answers 401 until authenticated, so an available-but-
   // anonymous backend can only render an empty stateful canvas. Fall through
   // to the sample instead: without an OAuth app configured, nobody can sign in.
@@ -358,7 +364,31 @@ function wireEvents() {
 async function loadSample() {
   const res = await fetch(sampleURL);
   dom.input.value = await res.text();
+  state.demoBoardMeta = null;
   update();
+}
+
+async function loadDemoBoard() {
+  try {
+    const res = await fetch('/api/demo-board', { credentials: 'same-origin' });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const payload = await res.json();
+    state.data = normalizeExport(payload);
+    state.data.brief_type = payload.brief_type || '';
+    state.demoBoardMeta = {
+      generated_at: payload.snapshot_generated_at || '',
+      stale: Boolean(payload.snapshot_stale),
+      age_sec: Number(payload.snapshot_age_sec || 0),
+    };
+    dom.input.value = snapshotToFlow(state.data.snapshot);
+    dom.status.textContent = payload.snapshot_stale ? 'private board snapshot loaded - stale' : 'private board snapshot loaded';
+    render();
+  } catch (err) {
+    state.demoBoardMeta = null;
+    dom.error.textContent = err.message;
+    dom.status.textContent = 'private board load failed';
+    loadSample();
+  }
 }
 
 function readFile(event) {
@@ -1349,7 +1379,7 @@ async function refreshBackendSession() {
     if (!res.ok) throw new Error(String(res.status));
     state.backendSession = { available: true, ...await res.json() };
   } catch {
-    state.backendSession = { available: false, authenticated: false, github_oauth_configured: false, github_app_configured: false };
+    state.backendSession = { available: false, authenticated: false, basic_authenticated: false, demo_board_available: false, github_oauth_configured: false, github_app_configured: false };
   }
   refreshBackendAuthUI();
   document.querySelector('[data-mode="stateful"]').disabled = !state.backendSession.available;
@@ -2577,7 +2607,10 @@ function render() {
   const graphSelection = graphVisibleNodeSelection(snapshot, nodes);
   dom.shell.classList.toggle('emptyBoard', snapshot.nodes.length === 0);
   dom.boardTitle.textContent = snapshot.board.name || 'Default';
-  dom.boardMeta.textContent = `${snapshot.nodes.length} nodes - ${snapshot.edges.length} edges`;
+  const freshness = state.demoBoardMeta?.generated_at
+    ? ` - snapshot ${state.demoBoardMeta.stale ? 'stale ' : ''}${state.demoBoardMeta.generated_at}`
+    : '';
+  dom.boardMeta.textContent = `${snapshot.nodes.length} nodes - ${snapshot.edges.length} edges${freshness}`;
   renderFilterChips();
   renderWorkspaceSummary();
   renderStats(brief.counts || {}, snapshot);
@@ -2634,6 +2667,18 @@ function renderStatefulSignedOut() {
 }
 
 function renderStats(counts, snapshot) {
+  if (isBoardStatusBrief(state.data.brief)) {
+    const values = [
+      ['● Open', counts.open || 0],
+      ['✅ Ready', counts.pullable || 0],
+      ['🟢 Active', statusCount(state.data.brief, 'active')],
+      ['👀 Review', statusCount(state.data.brief, 'review')],
+      ['⛔ Blocked', statusCount(state.data.brief, 'blocked')],
+      ['⚠ Untriaged', counts.untriaged || 0],
+    ];
+    dom.stats.innerHTML = values.map(([label, value]) => `<div class="stat"><span>${label}</span><strong>${value}</strong></div>`).join('');
+    return;
+  }
   const values = [
     ['● Nodes', counts.nodes || 0],
     ['💡 Suggested', suggestedEdges(snapshot).length],
@@ -2650,6 +2695,19 @@ function renderBrief(brief) {
     renderEmptyBoardBrief();
     return;
   }
+  if (isBoardStatusBrief(brief)) {
+    const freshness = state.demoBoardMeta?.generated_at
+      ? [{ id: state.demoBoardMeta.stale ? 'stale' : 'fresh', title: state.demoBoardMeta.generated_at, reason: state.demoBoardMeta.stale ? 'serving last private snapshot; no live fallback attempted' : 'private snapshot freshness' }]
+      : [];
+    dom.brief.innerHTML = `<div class="briefGrid">
+      ${freshness.length ? briefSection('Snapshot freshness', freshness, true) : ''}
+      ${statusHistogramSection(brief)}
+      ${briefSection('Pullable now', brief.pullable || [], true)}
+      ${briefSection('Blocked ready', brief.blocked || [], false)}
+      ${briefSection('Untriaged', brief.untriaged || [], false)}
+    </div>`;
+    return;
+  }
   const githubRefresh = state.githubRefresh.length
     ? briefSection('GitHub refresh', state.githubRefresh, false)
     : '';
@@ -2663,6 +2721,24 @@ function renderBrief(brief) {
     ${briefSection('Local-only', brief.local_only || [], false)}
     ${briefSection('Stale external state', brief.stale || [], false)}
   </div>`;
+}
+
+function isBoardStatusBrief(brief) {
+  return Boolean(brief && brief.counts && Array.isArray(brief.statuses) && Array.isArray(brief.pullable));
+}
+
+function statusCount(brief, status) {
+  const row = (brief.statuses || []).find((item) => item.status === status);
+  return row ? Number(row.count || 0) : 0;
+}
+
+function statusHistogramSection(brief) {
+  const items = (brief.statuses || []).map((item) => ({
+    id: `status:${item.status}`,
+    title: String(item.count || 0),
+    reason: 'workflow status count',
+  }));
+  return briefSection('Status histogram', items, true);
 }
 
 function renderEmptyBoardBrief() {

--- a/scripts/check-deploy.sh
+++ b/scripts/check-deploy.sh
@@ -2,8 +2,8 @@
 # Post-deploy contract for a depviz server (BRIEF-112).
 #
 # A green /api/health only proves the process is up. It says nothing about whether
-# the embedded Live SPA actually embedded, so this also fetches / and asserts the
-# app really shipped. Health-green + /-broken is the failure this exists to catch.
+# the landing and embedded app actually shipped, so this checks /, /app/, and the
+# authenticated demo-board data path when credentials are provided.
 #
 # Usage: scripts/check-deploy.sh [base-url]
 #   BASE_URL           default https://depviz.1789.tech
@@ -28,33 +28,49 @@ case "${health}" in
   *) fail "/api/health did not report ok:true: ${health}" ;;
 esac
 
-# 2. / serves the SPA. Separate the status code from the body so a 401 on a gated
-#    instance is reported as "credentials needed", not as a missing embed.
+# 2. / serves the public landing. It must stay open even when /app/ is gated.
 root_body="$("${CURL[@]}" --write-out '\n%{http_code}' "${BASE_URL}/")" || fail "/ unreachable"
 root_code="${root_body##*$'\n'}"
 root_html="${root_body%$'\n'*}"
-if [[ "${root_code}" == "401" ]]; then
-  fail "/ returned 401 — instance is gated, set DEPVIZ_BASIC_AUTH to check it"
-fi
 [[ "${root_code}" == "200" ]] || fail "/ returned ${root_code}, want 200"
 printf '  ok: / returned 200\n'
-
-# 3. the response is really the Live app, not a stray index or an error page.
-#    This is the "embed didn't embed" check: the binary serves live/app via go:embed.
 case "${root_html}" in
-  *'app.js'*) printf '  ok: / served the embedded Live SPA\n' ;;
-  *) fail "/ returned 200 but no app.js reference — the embedded Live FS did not embed" ;;
+  *'DepViz'*) printf '  ok: / served the landing page\n' ;;
+  *) fail "/ returned 200 but does not look like the DepViz landing page" ;;
+esac
+
+# 3. /app/ serves the embedded Live app. On a gated instance, missing
+#    DEPVIZ_BASIC_AUTH should fail clearly.
+app_body="$("${CURL[@]}" --write-out '\n%{http_code}' "${BASE_URL}/app/")" || fail "/app/ unreachable"
+app_code="${app_body##*$'\n'}"
+app_html="${app_body%$'\n'*}"
+if [[ "${app_code}" == "401" ]]; then
+  fail "/app/ returned 401 — instance is gated, set DEPVIZ_BASIC_AUTH to check it"
+fi
+[[ "${app_code}" == "200" ]] || fail "/app/ returned ${app_code}, want 200"
+case "${app_html}" in
+  *'app.js'*) printf '  ok: /app/ served the embedded Live SPA\n' ;;
+  *) fail "/app/ returned 200 but no app.js reference — the embedded Live FS did not embed" ;;
 esac
 
 # 4. the SPA's own assets resolve, which a partial embed would break.
 for asset in app.js style.css; do
-  code="$("${CURL[@]}" --output /dev/null --write-out '%{http_code}' "${BASE_URL}/${asset}")" || fail "/${asset} unreachable"
-  [[ "${code}" == "200" ]] || fail "/${asset} returned ${code}, want 200"
-  printf '  ok: /%s returned 200\n' "${asset}"
+  code="$("${CURL[@]}" --output /dev/null --write-out '%{http_code}' "${BASE_URL}/app/${asset}")" || fail "/app/${asset} unreachable"
+  [[ "${code}" == "200" ]] || fail "/app/${asset} returned ${code}, want 200"
+  printf '  ok: /app/%s returned 200\n' "${asset}"
 done
 
-# NOTE: the brief's fourth assertion — "the demo board renders >=1 card" — is not
-# checked yet: there is no demo board to render. It is blocked on the access
-# decision in BRIEF-112 and lands with that slice.
+# 5. The private board endpoint must not degrade to a public 200-empty response.
+demo_code="$("${CURL[@]}" --output /tmp/depviz-demo-board.json --write-out '%{http_code}' "${BASE_URL}/api/demo-board")" || fail "/api/demo-board unreachable"
+if [[ -n "${DEPVIZ_BASIC_AUTH:-}" ]]; then
+  [[ "${demo_code}" == "200" ]] || fail "/api/demo-board returned ${demo_code}, want 200 with credentials"
+  case "$(cat /tmp/depviz-demo-board.json)" in
+    *'"brief_type":"board-status"'*|*'"brief_type": "board-status"'*) printf '  ok: authenticated demo board returned board-status data\n' ;;
+    *) fail "/api/demo-board returned 200 but no board-status payload" ;;
+  esac
+else
+  [[ "${demo_code}" == "401" || "${demo_code}" == "403" || "${demo_code}" == "404" ]] || fail "/api/demo-board returned ${demo_code}, want 401/403/404 without credentials"
+  printf '  ok: anonymous demo board did not return private data (%s)\n' "${demo_code}"
+fi
 
 printf 'post-deploy contract passed\n'


### PR DESCRIPTION
Implements the DEC-0126/DEC-0127 split-audience private demo board path for 1789-tech/job-board#112.

- authenticated GET /api/demo-board renders a private Hermes board-snapshot.json as board-status data
- authenticated PUT /api/demo-board validates and atomically replaces the configured snapshot file
- anonymous/no-gate requests do not receive or write private board data
- /app/ cold-opens the authenticated private board when available; anonymous users keep the sample board
- docker-compose/README document DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE and DEPVIZ_DEMO_BOARD_MAX_AGE=90m

Companion private wiring PR: moul/1789.tech#9.

Local verification:
- /home/russel/.local/opt/go/bin/go test ./...
- bash -n scripts/check-deploy.sh
- node --check live/app/app.js
- git diff --check

Live anonymous pre-merge check (2026-07-17): /api/health 200 ok:true, / 200, /app/ 200, /api/demo-board 404. Authenticated live push/check is blocked until #722 is merged/deployed and Dokploy has DEPVIZ_BASIC_AUTH + DEPVIZ_DEMO_BOARD_SNAPSHOT_FILE + DEPVIZ_DEMO_BOARD_MAX_AGE configured.