### PR TITLE
fix: count demo-board done rows as closed

### DIFF
--- a/internal/backend/demo_board.go
+++ b/internal/backend/demo_board.go
@@ -35,14 +35,31 @@ type hermesBoardSnapshot struct {
 }
 
 type hermesBoardIssue struct {
-	Number  int    `json:"number"`
-	Title   string `json:"title"`
-	URL     string `json:"url"`
-	Project string `json:"project"`
-	Status  string `json:"status"`
-	Prio    string `json:"prio"`
-	Type    string `json:"type"`
-	Rank    int    `json:"rank"`
+	Number   int    `json:"number"`
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+	Project  string `json:"project"`
+	Status   string `json:"status"`
+	Prio     string `json:"prio"`
+	Type     string `json:"type"`
+	Rank     int    `json:"rank"`
+	ClosedAt string `json:"closed_at"`
+}
+
+func (i *hermesBoardIssue) UnmarshalJSON(data []byte) error {
+	type issueAlias hermesBoardIssue
+	var raw struct {
+		issueAlias
+		LegacyClosedAt string `json:"ClosedAt"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*i = hermesBoardIssue(raw.issueAlias)
+	if i.ClosedAt == "" {
+		i.ClosedAt = raw.LegacyClosedAt
+	}
+	return nil
 }
 
 func (s *Server) demoBoardConfigured() bool {
@@ -173,15 +190,26 @@ func parseDemoBoard(r io.Reader, maxAge time.Duration) (demoBoardPayload, error)
 }
 
 func (h hermesBoardSnapshot) toDepVizSnapshot(generatedAt time.Time) core.Snapshot {
-	issues := map[int]hermesBoardIssue{}
-	for _, rows := range [][]hermesBoardIssue{h.Open, h.Done, h.Queue} {
+	type issueEntry struct {
+		issue  hermesBoardIssue
+		closed bool
+	}
+	issues := map[int]issueEntry{}
+	addIssues := func(rows []hermesBoardIssue, closed bool) {
 		for _, issue := range rows {
 			if issue.Number == 0 {
 				continue
 			}
-			issues[issue.Number] = issue
+			prev, exists := issues[issue.Number]
+			if exists && prev.closed {
+				continue
+			}
+			issues[issue.Number] = issueEntry{issue: issue, closed: closed}
 		}
 	}
+	addIssues(h.Open, false)
+	addIssues(h.Queue, false)
+	addIssues(h.Done, true)
 	numbers := make([]int, 0, len(issues))
 	for n := range issues {
 		numbers = append(numbers, n)
@@ -189,7 +217,8 @@ func (h hermesBoardSnapshot) toDepVizSnapshot(generatedAt time.Time) core.Snapsh
 	sort.Ints(numbers)
 	nodes := make([]core.Node, 0, len(numbers))
 	for _, number := range numbers {
-		nodes = append(nodes, hermesIssueToNode(issues[number], generatedAt))
+		entry := issues[number]
+		nodes = append(nodes, hermesIssueToNode(entry.issue, generatedAt, entry.closed))
 	}
 	return core.Snapshot{
 		Board: core.Board{
@@ -212,9 +241,13 @@ func (h hermesBoardSnapshot) toDepVizSnapshot(generatedAt time.Time) core.Snapsh
 	}
 }
 
-func hermesIssueToNode(issue hermesBoardIssue, generatedAt time.Time) core.Node {
+func hermesIssueToNode(issue hermesBoardIssue, generatedAt time.Time, closed bool) core.Node {
 	status := strings.TrimPrefix(issue.Status, "status:")
 	state := status
+	if closed || strings.TrimSpace(issue.ClosedAt) != "" {
+		state = "closed"
+		status = firstNonEmpty(status, "done")
+	}
 	if state == "" {
 		state = "open"
 	}
@@ -246,6 +279,15 @@ func hermesIssueToNode(issue hermesBoardIssue, generatedAt time.Time) core.Node 
 		SourceID:   "github:1789-tech/job-board",
 		ExternalID: fmt.Sprintf("#%d", issue.Number),
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func countOpen(nodes []core.Node) int {

--- a/internal/backend/demo_board_test.go
+++ b/internal/backend/demo_board_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -137,6 +138,47 @@ func TestDemoBoardPutReplacesSnapshot(t *testing.T) {
 	}
 	if payload.Brief.Counts.Pullable != 1 {
 		t.Fatalf("pullable after PUT = %d, want 1", payload.Brief.Counts.Pullable)
+	}
+}
+
+func TestDemoBoardSnapshotDoneRowsAreClosed(t *testing.T) {
+	generatedAt := time.Now().UTC()
+	payload, err := parseDemoBoard(strings.NewReader(`{
+  "generated_at": "`+generatedAt.Format(time.RFC3339)+`",
+  "queue": [
+    {"number": 112, "title": "Claimed private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "active", "prio": "normal", "type": "build", "rank": 1},
+    {"number": 100, "title": "Closed duplicate in queue", "url": "https://github.com/1789-tech/job-board/issues/100", "project": "depviz", "status": "ready", "prio": "normal", "type": "build", "rank": 2}
+  ],
+  "open": [
+    {"number": 112, "title": "Claimed private brief", "url": "https://github.com/1789-tech/job-board/issues/112", "project": "depviz", "status": "active", "prio": "normal", "type": "build", "rank": 1},
+    {"number": 113, "title": "Untriaged open private brief", "url": "https://github.com/1789-tech/job-board/issues/113", "project": "boussole", "prio": "normal", "type": "brief", "rank": 3}
+  ],
+  "done": [
+    {"number": 100, "title": "Done private brief", "url": "https://github.com/1789-tech/job-board/issues/100", "project": "depviz", "ClosedAt": "2026-07-09T11:04:00Z"},
+    {"number": 101, "title": "Done lower-case private brief", "url": "https://github.com/1789-tech/job-board/issues/101", "project": "depviz", "closed_at": "2026-07-08T08:06:05Z"}
+  ]
+}`), time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.Brief.Counts.Open != 2 {
+		t.Fatalf("open = %d, want 2", payload.Brief.Counts.Open)
+	}
+	if payload.Brief.Counts.Closed != 2 {
+		t.Fatalf("closed = %d, want 2", payload.Brief.Counts.Closed)
+	}
+	if payload.Brief.Counts.Untriaged != 1 {
+		t.Fatalf("untriaged = %d, want 1", payload.Brief.Counts.Untriaged)
+	}
+	for _, item := range payload.Brief.Untriaged {
+		if strings.HasSuffix(item.ID, "#100") || strings.HasSuffix(item.ID, "#101") {
+			t.Fatalf("closed issue listed as untriaged: %+v", item)
+		}
+	}
+	for _, node := range payload.Snapshot.Nodes {
+		if node.ExternalID == "#100" && node.State != "closed" {
+			t.Fatalf("done row duplicated in queue should stay closed: %+v", node)
+		}
 	}
 }
 


### PR DESCRIPTION
Issue: https://github.com/1789-tech/job-board/issues/112

## Summary
- Preserve Hermes snapshot bucket provenance so rows from `done` become closed nodes even when they have no `status` field.
- Treat `closed_at` as an additional closed signal and tolerate the legacy `ClosedAt` key already present in pushed snapshots.
- Add a regression test covering done rows without status, legacy/future closed timestamp keys, and a done row that also appears in the queue.

## Verification
- `/home/russel/.local/opt/go/bin/go test ./...`
- Local authenticated `/api/demo-board` against a fresh real snapshot: counts returned `open:28`, `closed:25`, `untriaged:0`; anonymous returned `401`.

Not run: authenticated verification against `https://depviz.1789.tech/api/demo-board` because `DEPVIZ_BASIC_AUTH` is not present in this environment.
